### PR TITLE
Address scaffold review findings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v4
 
@@ -20,6 +25,11 @@ jobs:
           GOOS=linux GOARCH=arm64 go build -o bootstrap ./cmd/server
           zip lambda.zip bootstrap
 
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
       - uses: hashicorp/setup-terraform@v3
 
       - name: terraform init
@@ -29,17 +39,17 @@ jobs:
             -backend-config="dynamodb_table=${{ secrets.TF_STATE_BUCKET }}-lock"
         working-directory: terraform
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_state_bucket: ${{ secrets.TF_STATE_BUCKET }}
 
-      - name: terraform apply
-        run: terraform apply -auto-approve
+      - name: terraform plan
+        run: terraform plan -out=tfplan
         working-directory: terraform
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_state_bucket: ${{ secrets.TF_STATE_BUCKET }}
           TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
           TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           TF_VAR_admin_google_ids: ${{ secrets.ADMIN_GOOGLE_IDS }}
+
+      - name: terraform apply
+        run: terraform apply -auto-approve tfplan
+        working-directory: terraform

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: go vet ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.12.0
 
   terraform:
     runs-on: ubuntu-latest

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
 	log.Println("listening on :3000")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,30 +26,30 @@ services:
       AWS_SECRET_ACCESS_KEY: local
       AWS_DEFAULT_REGION: us-east-1
     entrypoint: /bin/sh
-    command: -c |
-      aws dynamodb create-table \
-        --endpoint-url http://dynamodb:8000 \
-        --table-name notoriousmcp \
-        --attribute-definitions \
-          AttributeName=PK,AttributeType=S \
-          AttributeName=SK,AttributeType=S \
-          AttributeName=GSI1PK,AttributeType=S \
-          AttributeName=GSI1SK,AttributeType=S \
-        --key-schema \
-          AttributeName=PK,KeyType=HASH \
-          AttributeName=SK,KeyType=RANGE \
-        --global-secondary-indexes '[
-          {
-            "IndexName": "GSI1",
-            "KeySchema": [
-              {"AttributeName":"GSI1PK","KeyType":"HASH"},
-              {"AttributeName":"GSI1SK","KeyType":"RANGE"}
-            ],
-            "Projection": {"ProjectionType":"ALL"}
-          }
-        ]' \
-        --billing-mode PAY_PER_REQUEST && \
-      aws --endpoint-url http://minio:9000 s3 mb s3://notoriousmcp-local
+    command: >-
+      -c "
+      aws dynamodb describe-table
+        --endpoint-url http://dynamodb:8000
+        --table-name notoriousmcp
+        > /dev/null 2>&1
+      || aws dynamodb create-table
+        --endpoint-url http://dynamodb:8000
+        --table-name notoriousmcp
+        --attribute-definitions
+          AttributeName=PK,AttributeType=S
+          AttributeName=SK,AttributeType=S
+          AttributeName=GSI1PK,AttributeType=S
+          AttributeName=GSI1SK,AttributeType=S
+        --key-schema
+          AttributeName=PK,KeyType=HASH
+          AttributeName=SK,KeyType=RANGE
+        --global-secondary-indexes '[{\"IndexName\":\"GSI1\",\"KeySchema\":[{\"AttributeName\":\"GSI1PK\",\"KeyType\":\"HASH\"},{\"AttributeName\":\"GSI1SK\",\"KeyType\":\"RANGE\"}],\"Projection\":{\"ProjectionType\":\"ALL\"}}]'
+        --billing-mode PAY_PER_REQUEST
+      ;
+      aws --endpoint-url http://minio:9000 s3 ls s3://notoriousmcp-local
+        > /dev/null 2>&1
+      || aws --endpoint-url http://minio:9000 s3 mb s3://notoriousmcp-local
+      "
 
   server:
     build: .

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/pwntato/notoriousmcp
 
 go 1.26.2
 
-require github.com/aws/aws-lambda-go v1.54.0 // indirect
+require github.com/aws/aws-lambda-go v1.54.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,10 @@
 github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,5 +1,13 @@
 locals {
   lambda_url_host = replace(aws_lambda_function_url.main.function_url, "https://", "")
+  cf_origin_id    = "lambda"
+}
+
+resource "aws_cloudfront_origin_access_control" "lambda" {
+  name                              = "notoriousmcp-lambda-oac-${var.environment}"
+  origin_access_control_origin_type = "lambda"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
 }
 
 resource "aws_cloudfront_distribution" "main" {
@@ -10,8 +18,9 @@ resource "aws_cloudfront_distribution" "main" {
   aliases = var.domain_name != "" ? [var.domain_name] : []
 
   origin {
-    domain_name = local.lambda_url_host
-    origin_id   = "lambda"
+    domain_name              = local.lambda_url_host
+    origin_id                = local.cf_origin_id
+    origin_access_control_id = aws_cloudfront_origin_access_control.lambda.id
 
     custom_origin_config {
       http_port              = 80
@@ -22,7 +31,7 @@ resource "aws_cloudfront_distribution" "main" {
   }
 
   default_cache_behavior {
-    target_origin_id       = "lambda"
+    target_origin_id       = local.cf_origin_id
     viewer_protocol_policy = "redirect-to-https"
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]
@@ -41,10 +50,10 @@ resource "aws_cloudfront_distribution" "main" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = var.domain_name != "" ? aws_acm_certificate_validation.main[0].certificate_arn : null
+    acm_certificate_arn            = var.domain_name != "" ? aws_acm_certificate_validation.main[0].certificate_arn : null
     cloudfront_default_certificate = var.domain_name == ""
-    ssl_support_method       = var.domain_name != "" ? "sni-only" : null
-    minimum_protocol_version = var.domain_name != "" ? "TLSv1.2_2021" : null
+    ssl_support_method             = var.domain_name != "" ? "sni-only" : null
+    minimum_protocol_version       = var.domain_name != "" ? "TLSv1.2_2021" : null
   }
 
   restrictions {

--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -1,0 +1,107 @@
+data "aws_caller_identity" "current" {}
+
+# OIDC provider for GitHub Actions — create once per AWS account
+# If you already have this provider, import it rather than creating a new one:
+#   terraform import aws_iam_openid_connect_provider.github arn:aws:iam::<account_id>:oidc-provider/token.actions.githubusercontent.com
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+data "aws_iam_policy_document" "deploy_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:pwntato/notoriousmcp:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role" "deploy" {
+  name               = "notoriousmcp-deploy-${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.deploy_assume_role.json
+}
+
+data "aws_iam_policy_document" "deploy_policy" {
+  statement {
+    actions   = ["lambda:UpdateFunctionCode", "lambda:GetFunction"]
+    resources = [aws_lambda_function.main.arn]
+  }
+
+  statement {
+    actions = [
+      "lambda:CreateFunctionUrlConfig",
+      "lambda:UpdateFunctionUrlConfig",
+      "lambda:GetFunctionUrlConfig",
+      "lambda:AddPermission",
+      "lambda:RemovePermission",
+    ]
+    resources = [aws_lambda_function.main.arn]
+  }
+
+  statement {
+    actions = [
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetDistribution",
+      "cloudfront:UpdateDistribution",
+    ]
+    resources = [aws_cloudfront_distribution.main.arn]
+  }
+
+  statement {
+    actions = [
+      "ssm:PutParameter",
+      "ssm:GetParameter",
+    ]
+    resources = [
+      aws_ssm_parameter.google_client_id.arn,
+      aws_ssm_parameter.google_client_secret.arn,
+      aws_ssm_parameter.admin_google_ids.arn,
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.state_bucket}",
+      "arn:aws:s3:::${var.state_bucket}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = ["arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${var.state_bucket}-lock"]
+  }
+}
+
+resource "aws_iam_role_policy" "deploy" {
+  name   = "notoriousmcp-deploy-policy"
+  role   = aws_iam_role.deploy.id
+  policy = data.aws_iam_policy_document.deploy_policy.json
+}
+
+output "deploy_role_arn" {
+  value       = aws_iam_role.deploy.arn
+  description = "Set this as the AWS_DEPLOY_ROLE_ARN GitHub Actions secret"
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "lambda_policy" {
   }
 
   statement {
-    actions   = ["ssm:GetParameter"]
+    actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.google_client_id.arn,
       aws_ssm_parameter.google_client_secret.arn,
@@ -77,12 +77,12 @@ resource "aws_lambda_function" "main" {
 
   environment {
     variables = {
-      TABLE_NAME                  = var.table_name
-      S3_BUCKET                   = aws_s3_bucket.content.bucket
-      ENVIRONMENT                 = var.environment
-      SSM_GOOGLE_CLIENT_ID        = aws_ssm_parameter.google_client_id.name
-      SSM_GOOGLE_CLIENT_SECRET    = aws_ssm_parameter.google_client_secret.name
-      SSM_ADMIN_GOOGLE_IDS        = aws_ssm_parameter.admin_google_ids.name
+      TABLE_NAME               = var.table_name
+      S3_BUCKET                = aws_s3_bucket.content.bucket
+      ENVIRONMENT              = var.environment
+      SSM_GOOGLE_CLIENT_ID     = aws_ssm_parameter.google_client_id.name
+      SSM_GOOGLE_CLIENT_SECRET = aws_ssm_parameter.google_client_secret.name
+      SSM_ADMIN_GOOGLE_IDS     = aws_ssm_parameter.admin_google_ids.name
     }
   }
 

--- a/terraform/lambda_url.tf
+++ b/terraform/lambda_url.tf
@@ -1,11 +1,15 @@
 resource "aws_lambda_function_url" "main" {
   function_name      = aws_lambda_function.main.function_name
-  authorization_type = "NONE"
+  authorization_type = "AWS_IAM"
+}
 
-  cors {
-    allow_origins = ["*"]
-    allow_methods = ["GET", "POST"]
-    allow_headers = ["authorization", "content-type"]
-    max_age       = 86400
-  }
+# Allow CloudFront OAC to invoke the Lambda URL
+resource "aws_lambda_permission" "cloudfront" {
+  statement_id  = "AllowCloudFrontInvoke"
+  action        = "lambda:InvokeFunctionUrl"
+  function_name = aws_lambda_function.main.function_name
+  principal     = "cloudfront.amazonaws.com"
+  source_arn    = aws_cloudfront_distribution.main.arn
+
+  function_url_auth_type = "AWS_IAM"
 }

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -7,48 +7,48 @@ resource "aws_route53domains_registered_domain" "main" {
   dynamic "registrant_contact" {
     for_each = [1]
     content {
-      first_name    = var.domain_contact_first_name
-      last_name     = var.domain_contact_last_name
+      first_name        = var.domain_contact_first_name
+      last_name         = var.domain_contact_last_name
       organization_name = var.domain_contact_organization
-      address_line_1 = var.domain_contact_address
-      city          = var.domain_contact_city
-      state         = var.domain_contact_state
-      zip_code      = var.domain_contact_zip
-      country_code  = var.domain_contact_country_code
-      phone_number  = var.domain_contact_phone
-      email         = var.domain_contact_email
+      address_line_1    = var.domain_contact_address
+      city              = var.domain_contact_city
+      state             = var.domain_contact_state
+      zip_code          = var.domain_contact_zip
+      country_code      = var.domain_contact_country_code
+      phone_number      = var.domain_contact_phone
+      email             = var.domain_contact_email
     }
   }
 
   dynamic "admin_contact" {
     for_each = [1]
     content {
-      first_name    = var.domain_contact_first_name
-      last_name     = var.domain_contact_last_name
+      first_name        = var.domain_contact_first_name
+      last_name         = var.domain_contact_last_name
       organization_name = var.domain_contact_organization
-      address_line_1 = var.domain_contact_address
-      city          = var.domain_contact_city
-      state         = var.domain_contact_state
-      zip_code      = var.domain_contact_zip
-      country_code  = var.domain_contact_country_code
-      phone_number  = var.domain_contact_phone
-      email         = var.domain_contact_email
+      address_line_1    = var.domain_contact_address
+      city              = var.domain_contact_city
+      state             = var.domain_contact_state
+      zip_code          = var.domain_contact_zip
+      country_code      = var.domain_contact_country_code
+      phone_number      = var.domain_contact_phone
+      email             = var.domain_contact_email
     }
   }
 
   dynamic "tech_contact" {
     for_each = [1]
     content {
-      first_name    = var.domain_contact_first_name
-      last_name     = var.domain_contact_last_name
+      first_name        = var.domain_contact_first_name
+      last_name         = var.domain_contact_last_name
       organization_name = var.domain_contact_organization
-      address_line_1 = var.domain_contact_address
-      city          = var.domain_contact_city
-      state         = var.domain_contact_state
-      zip_code      = var.domain_contact_zip
-      country_code  = var.domain_contact_country_code
-      phone_number  = var.domain_contact_phone
-      email         = var.domain_contact_email
+      address_line_1    = var.domain_contact_address
+      city              = var.domain_contact_city
+      state             = var.domain_contact_state
+      zip_code          = var.domain_contact_zip
+      country_code      = var.domain_contact_country_code
+      phone_number      = var.domain_contact_phone
+      email             = var.domain_contact_email
     }
   }
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -25,3 +25,16 @@ resource "aws_s3_bucket_versioning" "content" {
     status = "Enabled"
   }
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "content" {
+  bucket = aws_s3_bucket.content.id
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -7,6 +7,15 @@
 #   terraform init \
 #     -backend-config="bucket=YOUR_STATE_BUCKET" \
 #     -backend-config="dynamodb_table=YOUR_STATE_BUCKET-lock"
+#
+# GitHub Actions secrets required:
+#   TF_STATE_BUCKET       — same as state_bucket above
+#   AWS_DEPLOY_ROLE_ARN   — output of `terraform output deploy_role_arn` after first apply
+#   GOOGLE_CLIENT_ID      — from Google Cloud Console
+#   GOOGLE_CLIENT_SECRET  — from Google Cloud Console
+#   ADMIN_GOOGLE_IDS      — comma-separated Google subject IDs
+#
+# Note: No AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY needed — CI uses OIDC federation.
 
 # Required
 state_bucket         = "notoriousmcp-tfstate-YOUR_ACCOUNT_ID"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -81,8 +81,8 @@ variable "domain_contact_country_code" {
 }
 
 variable "domain_contact_phone" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "E.164 format, e.g. +1.5555550100"
 }
 


### PR DESCRIPTION
## Summary

- **Lambda URL security**: switched to `AWS_IAM` auth + CloudFront OAC — the raw Lambda URL is now inaccessible without a signed AWS request; only CloudFront can invoke it
- **CI: OIDC federation**: replaced static `AWS_ACCESS_KEY_ID`/`SECRET` with `aws-actions/configure-aws-credentials` + an OIDC-federated deploy role (`iam_deploy.tf`); no long-lived credentials in GitHub secrets
- **CI: terraform plan**: added `terraform plan -out=tfplan` step before apply so every deploy logs what's changing
- **S3 versioning cleanup**: lifecycle rule expires non-current object versions after 30 days
- **docker-compose idempotency**: init container now checks before creating DynamoDB table and MinIO bucket — safe to restart
- **go mod tidy**: removed `// indirect` from `aws-lambda-go`

## What's NOT addressed here

- WAF (#7 in review) — deferred, Terraform-only change, can be added later
- Terraform plan approval gate — deferred per discussion; `-auto-approve` is fine for now
- Refresh token encryption (#9) — SSE-at-rest + TLS is sufficient for this threat model

## Post-merge setup note

After first `terraform apply`, run:
```
terraform output deploy_role_arn
```
and set the result as the `AWS_DEPLOY_ROLE_ARN` GitHub Actions secret. This replaces `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`.

## Test plan

- [ ] Verify `go build ./...` passes
- [ ] Verify `terraform validate` passes in both `terraform/` and `terraform/bootstrap/`
- [ ] After deploy: confirm direct Lambda URL returns 403, CloudFront URL returns 200