### PR TITLE
Address second review: license, streaming, TTL, mux, OIDC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jimmy (pwntato)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -6,11 +6,12 @@ import (
 )
 
 func main() {
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
 	log.Println("listening on :3000")
-	log.Fatal(http.ListenAndServe(":3000", nil))
+	log.Fatal(http.ListenAndServe(":3000", mux))
 }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -38,4 +38,9 @@ resource "aws_dynamodb_table" "main" {
   point_in_time_recovery {
     enabled = true
   }
+
+  ttl {
+    attribute_name = "TTL"
+    enabled        = false
+  }
 }

--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -4,9 +4,11 @@ data "aws_caller_identity" "current" {}
 # If you already have this provider, import it rather than creating a new one:
 #   terraform import aws_iam_openid_connect_provider.github arn:aws:iam::<account_id>:oidc-provider/token.actions.githubusercontent.com
 resource "aws_iam_openid_connect_provider" "github" {
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  # AWS ignores thumbprint_list for token.actions.githubusercontent.com — required by the
+  # resource schema but has no effect; any non-empty value satisfies the provider.
+  thumbprint_list = ["0000000000000000000000000000000000000000"]
 }
 
 data "aws_iam_policy_document" "deploy_assume_role" {
@@ -61,6 +63,9 @@ data "aws_iam_policy_document" "deploy_policy" {
   }
 
   statement {
+    # ssm:PutParameter allows CI to rotate OAuth credentials and admin IDs via terraform apply.
+    # This is intentional — Terraform manages these values — but means anyone who can push to
+    # main (currently only pwntato) can overwrite production secrets.
     actions = [
       "ssm:PutParameter",
       "ssm:GetParameter",

--- a/terraform/lambda_url.tf
+++ b/terraform/lambda_url.tf
@@ -1,6 +1,7 @@
 resource "aws_lambda_function_url" "main" {
   function_name      = aws_lambda_function.main.function_name
   authorization_type = "AWS_IAM"
+  invoke_mode        = "RESPONSE_STREAM"
 }
 
 # Allow CloudFront OAC to invoke the Lambda URL


### PR DESCRIPTION
## Summary

Changes missed from PR #14 merge:

- **MIT LICENSE** — adds `LICENSE` file
- **Lambda URL streaming** — `invoke_mode = "RESPONSE_STREAM"` for SSE support (must be set before any clients connect)
- **DynamoDB TTL** — adds `ttl` block (disabled by default, ready for OAuth state/session token expiry)
- **Explicit HTTP mux** — `cmd/local` now uses `http.NewServeMux()` instead of `http.DefaultServeMux`
- **OIDC thumbprint** — clarifies the value is a no-op for `token.actions.githubusercontent.com`; documents that `ssm:PutParameter` in the deploy role is intentional

## Test plan

- [ ] CI passes (go test, golangci-lint, terraform fmt/validate)
- [ ] `LICENSE` file present at repo root