### PR TITLE
feat(store): S3 content store and CI integration tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ S3_BUCKET=notoriousmcp-local
 TABLE_NAME=notoriousmcp
 ENVIRONMENT=local
 
+# MinIO local credentials (must match docker-compose MINIO_ROOT_USER/PASSWORD)
+# MinIO requires: user >= 3 chars, password >= 8 chars
+AWS_ACCESS_KEY_ID=localuser
+AWS_SECRET_ACCESS_KEY=localpassword
+
 # Admin bootstrap: comma-separated Google subject IDs
 # Get your sub by logging in once and checking the DynamoDB USER#<sub>#PROFILE item
 ADMIN_GOOGLE_IDS=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
         run: |
           aws dynamodb create-table \
-            --endpoint-url http://localhost:8000 \
+            --endpoint-url http://127.0.0.1:8000 \
             --table-name notoriousmcp \
             --attribute-definitions \
               AttributeName=PK,AttributeType=S \
@@ -52,14 +52,14 @@ jobs:
             -e MINIO_ROOT_PASSWORD=local \
             minio/minio:latest server /data
           for i in $(seq 1 30); do
-            aws --endpoint-url http://localhost:9000 s3 mb s3://notoriousmcp-local 2>/dev/null && break || sleep 1
+            aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://notoriousmcp-local 2>/dev/null && break || sleep 1
           done
 
       - name: go test
         env:
-          DYNAMODB_ENDPOINT: http://localhost:8000
+          DYNAMODB_ENDPOINT: http://127.0.0.1:8000
           TABLE_NAME: notoriousmcp
-          S3_ENDPOINT: http://localhost:9000
+          S3_ENDPOINT: http://127.0.0.1:9000
           S3_BUCKET: notoriousmcp-local
           AWS_ACCESS_KEY_ID: local
           AWS_SECRET_ACCESS_KEY: local

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
             -p 9000:9000 \
             -e MINIO_ROOT_USER=localuser \
             -e MINIO_ROOT_PASSWORD=localpassword \
-            minio/minio:RELEASE.2025-10-15T17-29-55Z server /data
+            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           for i in $(seq 1 30); do
             aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://notoriousmcp-local 2>/dev/null && break || sleep 1
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,14 +42,14 @@ jobs:
 
       - name: start MinIO and init bucket
         env:
-          AWS_ACCESS_KEY_ID: local
-          AWS_SECRET_ACCESS_KEY: local
+          AWS_ACCESS_KEY_ID: localuser
+          AWS_SECRET_ACCESS_KEY: localpassword
           AWS_DEFAULT_REGION: us-east-1
         run: |
           docker run -d --name minio \
             -p 9000:9000 \
-            -e MINIO_ROOT_USER=local \
-            -e MINIO_ROOT_PASSWORD=local \
+            -e MINIO_ROOT_USER=localuser \
+            -e MINIO_ROOT_PASSWORD=localpassword \
             -v /tmp/minio-data:/data \
             minio/minio:latest server /data
           for i in $(seq 1 30); do
@@ -68,8 +68,8 @@ jobs:
           TABLE_NAME: notoriousmcp
           S3_ENDPOINT: http://127.0.0.1:9000
           S3_BUCKET: notoriousmcp-local
-          AWS_ACCESS_KEY_ID: local
-          AWS_SECRET_ACCESS_KEY: local
+          AWS_ACCESS_KEY_ID: localuser
+          AWS_SECRET_ACCESS_KEY: localpassword
           AWS_DEFAULT_REGION: us-east-1
         run: go test ./...
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,18 @@ jobs:
         ports:
           - 8000:8000
 
+      minio:
+        image: bitnami/minio:latest
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ROOT_USER: local
+          MINIO_ROOT_PASSWORD: local
+        options: >-
+          --health-cmd "curl -sf http://localhost:9000/minio/health/live"
+          --health-interval 3s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
 
@@ -40,21 +52,12 @@ jobs:
             --global-secondary-indexes '[{"IndexName":"GSI1","KeySchema":[{"AttributeName":"GSI1PK","KeyType":"HASH"},{"AttributeName":"GSI1SK","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"}}]' \
             --billing-mode PAY_PER_REQUEST
 
-      - name: start MinIO and init bucket
+      - name: init MinIO bucket
         env:
           AWS_ACCESS_KEY_ID: local
           AWS_SECRET_ACCESS_KEY: local
           AWS_DEFAULT_REGION: us-east-1
-        run: |
-          docker run -d --name minio \
-            -p 9000:9000 \
-            -e MINIO_ROOT_USER=local \
-            -e MINIO_ROOT_PASSWORD=local \
-            minio/minio server /data
-          for i in $(seq 1 30); do
-            curl -sf http://localhost:9000/minio/health/live && break || sleep 1
-          done
-          aws --endpoint-url http://localhost:9000 s3 mb s3://notoriousmcp-local
+        run: aws --endpoint-url http://localhost:9000 s3 mb s3://notoriousmcp-local
 
       - name: go test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,6 @@ jobs:
         image: amazon/dynamodb-local:latest
         ports:
           - 8000:8000
-        options: >-
-          --health-cmd "curl -sf http://localhost:8000"
-          --health-interval 5s
-          --health-retries 6
 
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +26,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: localpassword
           AWS_DEFAULT_REGION: us-east-1
         run: |
+          for i in $(seq 1 20); do
+            aws dynamodb list-tables --endpoint-url http://127.0.0.1:8000 2>/dev/null && break || sleep 1
+          done
           aws dynamodb create-table \
             --endpoint-url http://127.0.0.1:8000 \
             --table-name notoriousmcp \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    services:
+      dynamodb:
+        image: amazon/dynamodb-local:latest
+        ports:
+          - 8000:8000
+
     steps:
       - uses: actions/checkout@v4
 
@@ -13,7 +20,49 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: init DynamoDB table
+        env:
+          AWS_ACCESS_KEY_ID: local
+          AWS_SECRET_ACCESS_KEY: local
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          aws dynamodb create-table \
+            --endpoint-url http://localhost:8000 \
+            --table-name notoriousmcp \
+            --attribute-definitions \
+              AttributeName=PK,AttributeType=S \
+              AttributeName=SK,AttributeType=S \
+              AttributeName=GSI1PK,AttributeType=S \
+              AttributeName=GSI1SK,AttributeType=S \
+            --key-schema \
+              AttributeName=PK,KeyType=HASH \
+              AttributeName=SK,KeyType=RANGE \
+            --global-secondary-indexes '[{"IndexName":"GSI1","KeySchema":[{"AttributeName":"GSI1PK","KeyType":"HASH"},{"AttributeName":"GSI1SK","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"}}]' \
+            --billing-mode PAY_PER_REQUEST
+
+      - name: start MinIO and init bucket
+        env:
+          AWS_ACCESS_KEY_ID: minioadmin
+          AWS_SECRET_ACCESS_KEY: minioadmin
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio server /data
+          until curl -sf http://localhost:9000/minio/health/live; do sleep 1; done
+          aws --endpoint-url http://localhost:9000 s3 mb s3://notoriousmcp-local
+
       - name: go test
+        env:
+          DYNAMODB_ENDPOINT: http://localhost:8000
+          TABLE_NAME: notoriousmcp
+          S3_ENDPOINT: http://localhost:9000
+          S3_BUCKET: notoriousmcp-local
+          AWS_ACCESS_KEY_ID: local
+          AWS_SECRET_ACCESS_KEY: local
+          AWS_DEFAULT_REGION: us-east-1
         run: go test ./...
 
       - name: go vet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ jobs:
         image: amazon/dynamodb-local:latest
         ports:
           - 8000:8000
+        options: >-
+          --health-cmd "curl -sf http://localhost:8000"
+          --health-interval 5s
+          --health-retries 6
 
     steps:
       - uses: actions/checkout@v4
@@ -50,17 +54,10 @@ jobs:
             -p 9000:9000 \
             -e MINIO_ROOT_USER=localuser \
             -e MINIO_ROOT_PASSWORD=localpassword \
-            -v /tmp/minio-data:/data \
-            minio/minio:latest server /data
+            minio/minio:RELEASE.2025-10-15T17-29-55Z server /data
           for i in $(seq 1 30); do
             aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://notoriousmcp-local 2>/dev/null && break || sleep 1
           done
-          docker logs minio || true
-
-      - name: check services
-        run: |
-          docker ps -a
-          curl -sf http://127.0.0.1:9000/minio/health/live && echo "MinIO up" || echo "MinIO DOWN"
 
       - name: go test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,6 @@ jobs:
         ports:
           - 8000:8000
 
-      minio:
-        image: bitnami/minio:latest
-        ports:
-          - 9000:9000
-        env:
-          MINIO_ROOT_USER: local
-          MINIO_ROOT_PASSWORD: local
-        options: >-
-          --health-cmd "curl -sf http://localhost:9000/minio/health/live"
-          --health-interval 3s
-          --health-retries 10
-
     steps:
       - uses: actions/checkout@v4
 
@@ -52,12 +40,20 @@ jobs:
             --global-secondary-indexes '[{"IndexName":"GSI1","KeySchema":[{"AttributeName":"GSI1PK","KeyType":"HASH"},{"AttributeName":"GSI1SK","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"}}]' \
             --billing-mode PAY_PER_REQUEST
 
-      - name: init MinIO bucket
+      - name: start MinIO and init bucket
         env:
           AWS_ACCESS_KEY_ID: local
           AWS_SECRET_ACCESS_KEY: local
           AWS_DEFAULT_REGION: us-east-1
-        run: aws --endpoint-url http://localhost:9000 s3 mb s3://notoriousmcp-local
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=local \
+            -e MINIO_ROOT_PASSWORD=local \
+            minio/minio:latest server /data
+          for i in $(seq 1 30); do
+            aws --endpoint-url http://localhost:9000 s3 mb s3://notoriousmcp-local 2>/dev/null && break || sleep 1
+          done
 
       - name: go test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      AWS_ACCESS_KEY_ID: localuser
+      AWS_SECRET_ACCESS_KEY: localpassword
+      AWS_DEFAULT_REGION: us-east-1
+
     services:
       dynamodb:
         image: amazon/dynamodb-local:latest
@@ -21,10 +26,6 @@ jobs:
           go-version-file: go.mod
 
       - name: init DynamoDB table
-        env:
-          AWS_ACCESS_KEY_ID: localuser
-          AWS_SECRET_ACCESS_KEY: localpassword
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           for i in $(seq 1 20); do
             aws dynamodb list-tables --endpoint-url http://127.0.0.1:8000 2>/dev/null && break || sleep 1
@@ -46,10 +47,6 @@ jobs:
             --billing-mode PAY_PER_REQUEST
 
       - name: start MinIO and init bucket
-        env:
-          AWS_ACCESS_KEY_ID: localuser
-          AWS_SECRET_ACCESS_KEY: localpassword
-          AWS_DEFAULT_REGION: us-east-1
         run: |
           docker run -d --name minio \
             -p 9000:9000 \
@@ -68,9 +65,6 @@ jobs:
           TABLE_NAME: notoriousmcp
           S3_ENDPOINT: http://127.0.0.1:9000
           S3_BUCKET: notoriousmcp-local
-          AWS_ACCESS_KEY_ID: localuser
-          AWS_SECRET_ACCESS_KEY: localpassword
-          AWS_DEFAULT_REGION: us-east-1
         run: go test ./...
 
       - name: go vet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: init DynamoDB table
         env:
-          AWS_ACCESS_KEY_ID: local
-          AWS_SECRET_ACCESS_KEY: local
+          AWS_ACCESS_KEY_ID: localuser
+          AWS_SECRET_ACCESS_KEY: localpassword
           AWS_DEFAULT_REGION: us-east-1
         run: |
           aws dynamodb create-table \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,9 @@ jobs:
             -e MINIO_ROOT_USER=local \
             -e MINIO_ROOT_PASSWORD=local \
             minio/minio server /data
-          until curl -sf http://localhost:9000/minio/health/live; do sleep 1; done
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:9000/minio/health/live && break || sleep 1
+          done
           aws --endpoint-url http://localhost:9000 s3 mb s3://notoriousmcp-local
 
       - name: go test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,11 @@ jobs:
             aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://notoriousmcp-local 2>/dev/null && break || sleep 1
           done
 
+      - name: check services
+        run: |
+          docker ps -a
+          curl -sf http://127.0.0.1:9000/minio/health/live && echo "MinIO up" || echo "MinIO DOWN"
+
       - name: go test
         env:
           DYNAMODB_ENDPOINT: http://127.0.0.1:8000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
           for i in $(seq 1 20); do
             aws dynamodb list-tables --endpoint-url http://127.0.0.1:8000 2>/dev/null && break || sleep 1
           done
+          aws dynamodb list-tables --endpoint-url http://127.0.0.1:8000 > /dev/null || \
+            (echo "DynamoDB Local did not become ready in time"; exit 1)
           aws dynamodb create-table \
             --endpoint-url http://127.0.0.1:8000 \
             --table-name notoriousmcp \
@@ -57,6 +59,8 @@ jobs:
           for i in $(seq 1 30); do
             aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://notoriousmcp-local 2>/dev/null && break || sleep 1
           done
+          aws --endpoint-url http://127.0.0.1:9000 s3 ls s3://notoriousmcp-local > /dev/null || \
+            (echo "MinIO bucket init failed"; docker logs minio; exit 1)
 
       - name: go test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,14 +42,14 @@ jobs:
 
       - name: start MinIO and init bucket
         env:
-          AWS_ACCESS_KEY_ID: minioadmin
-          AWS_SECRET_ACCESS_KEY: minioadmin
+          AWS_ACCESS_KEY_ID: local
+          AWS_SECRET_ACCESS_KEY: local
           AWS_DEFAULT_REGION: us-east-1
         run: |
           docker run -d --name minio \
             -p 9000:9000 \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
+            -e MINIO_ROOT_USER=local \
+            -e MINIO_ROOT_PASSWORD=local \
             minio/minio server /data
           until curl -sf http://localhost:9000/minio/health/live; do sleep 1; done
           aws --endpoint-url http://localhost:9000 s3 mb s3://notoriousmcp-local

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,10 +50,12 @@ jobs:
             -p 9000:9000 \
             -e MINIO_ROOT_USER=local \
             -e MINIO_ROOT_PASSWORD=local \
+            -v /tmp/minio-data:/data \
             minio/minio:latest server /data
           for i in $(seq 1 30); do
             aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://notoriousmcp-local 2>/dev/null && break || sleep 1
           done
+          docker logs minio || true
 
       - name: check services
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      MINIO_ROOT_USER: local
-      MINIO_ROOT_PASSWORD: local
+      MINIO_ROOT_USER: localuser
+      MINIO_ROOT_PASSWORD: localpassword
     command: server /data --console-address ":9001"
 
   init:
@@ -22,8 +22,8 @@ services:
       - minio
     env_file: .env
     environment:
-      AWS_ACCESS_KEY_ID: local
-      AWS_SECRET_ACCESS_KEY: local
+      AWS_ACCESS_KEY_ID: localuser
+      AWS_SECRET_ACCESS_KEY: localpassword
       AWS_DEFAULT_REGION: us-east-1
     entrypoint: /bin/sh
     command: >-
@@ -62,8 +62,8 @@ services:
       S3_BUCKET: notoriousmcp-local
       TABLE_NAME: notoriousmcp
       ENVIRONMENT: local
-      AWS_ACCESS_KEY_ID: local
-      AWS_SECRET_ACCESS_KEY: local
+      AWS_ACCESS_KEY_ID: localuser
+      AWS_SECRET_ACCESS_KEY: localpassword
       AWS_DEFAULT_REGION: us-east-1
     depends_on:
       init:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: local
+      MINIO_ROOT_PASSWORD: local
     command: server /data --console-address ":9001"
 
   init:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000:9000"
       - "9001:9001"

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.39
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
@@ -18,8 +20,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFh
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.32.17 h1:FpL4/758/diKwqbytU0prpuiu60fgXKUWCpDJtApclU=
 github.com/aws/aws-sdk-go-v2/config v1.32.17/go.mod h1:OXqUMzgXytfoF9JaKkhrOYsyh72t9G+MJH8mMRaexOE=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.16 h1:r3RJBuU7X9ibt8RHbMjWE6y60QbKBiII6wSrXnapxSU=
@@ -22,10 +24,16 @@ github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.16 h1:nWMRNW3SFeJCdK7
 github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.16/go.mod h1:IMigEAstzWVC+mYsWLjZB/ZBJBLWON/Fl0zLHxZ18Qk=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9/go.mod h1:w7wZ/s9qK7c8g4al+UyoF1Sp/Z45UwMGcqIzLWVQHWk=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 h1:ieLCO1JxUWuxTZ1cRd0GAaeX7O6cIxnwk7tc1LsQhC4=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15/go.mod h1:e3IzZvQ3kAWNykvE0Tr0RDZCMFInMvhku3qNpcIQXhM=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.23 h1:3Eo/PBBnjFi1+gYfaL286dpmFSW3mTfodBIybq36Qv4=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.23/go.mod h1:3oh+5xGSd1iuxonVb3Qbm+WJYlbhczT9kbzr6doJLzY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 h1:pbrxO/kuIwgEsOPLkaHu0O+m4fNgLU8B3vxQ+72jTPw=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23/go.mod h1:/CMNUqoj46HpS3MNRDEDIwcgEnrtZlKRaHNaHxIFpNA=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 h1:03xatSQO4+AM1lTAbnRg5OK528EUg744nW7F73U8DKw=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23/go.mod h1:M8l3mwgx5ToK7wot2sBBce/ojzgnPzZXUV445gTSyE8=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1 h1:mxuT1xE+dI54NW3RkNjP8DUT5HXqbkiAFvfdyDFwE5c=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11/go.mod h1:R82ZRExE/nheo0N+T8zHPcLRTcH8MGsnR3BiVGX0TwI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 h1:7byT8HUWrgoRp6sXjxtZwgOKfhss5fW6SkLBtqzgRoE=

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -1,0 +1,5 @@
+package store
+
+import "errors"
+
+var ErrNotFound = errors.New("not found")

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -4,5 +4,5 @@ import "errors"
 
 var (
 	ErrNotFound = errors.New("not found")
-	ErrTooLarge = errors.New("content exceeds 1MB limit")
+	ErrTooLarge = errors.New("content too large")
 )

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -2,4 +2,7 @@ package store
 
 import "errors"
 
-var ErrNotFound = errors.New("not found")
+var (
+	ErrNotFound = errors.New("not found")
+	ErrTooLarge = errors.New("content exceeds 1MB limit")
+)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,8 +14,6 @@ import (
 
 const maxContentBytes = 1 << 20 // 1MB
 
-var ErrTooLarge = errors.New("content exceeds 1MB limit")
-
 // Client wraps the S3 client and bucket name.
 type Client struct {
 	s3     *s3.Client
@@ -73,6 +71,9 @@ func (c *Client) GetContent(ctx context.Context, key string) (string, error) {
 		if errors.As(err, &nsk) {
 			return "", ErrNotFound
 		}
+		// Note: S3 can also return a generic NotFound (e.g. bucket doesn't exist)
+		// which won't match NoSuchKey. In practice this server owns the bucket, so
+		// a missing bucket is a misconfiguration rather than a missing object.
 		return "", fmt.Errorf("get content %q: %w", key, err)
 	}
 	defer func() { _ = out.Body.Close() }()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,7 +32,10 @@ func New(ctx context.Context, bucket, endpoint string) (*Client, error) {
 	if endpoint != "" {
 		s3Opts = append(s3Opts, func(o *s3.Options) {
 			o.BaseEndpoint = &endpoint
-			o.UsePathStyle = true // MinIO requires path-style addressing
+			// Path-style addressing is required by MinIO and other S3-compatible
+			// stores. Intentionally gated on endpoint override — real AWS S3 uses
+			// virtual-hosted style and path-style is deprecated there.
+			o.UsePathStyle = true
 		})
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,7 +75,7 @@ func (c *Client) GetContent(ctx context.Context, key string) (string, error) {
 		}
 		return "", fmt.Errorf("get content %q: %w", key, err)
 	}
-	defer out.Body.Close()
+	defer func() { _ = out.Body.Close() }()
 
 	// Guard against oversized objects that shouldn't exist but could if
 	// someone wrote directly to the bucket bypassing the API.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+const maxContentBytes = 1 << 20 // 1MB
+
+var ErrTooLarge = errors.New("content exceeds 1MB limit")
+
+// Client wraps the S3 client and bucket name.
+type Client struct {
+	s3     *s3.Client
+	bucket string
+}
+
+// New creates an S3 store client. If endpoint is non-empty it overrides the
+// endpoint (for local dev with MinIO).
+func New(ctx context.Context, bucket, endpoint string) (*Client, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	var s3Opts []func(*s3.Options)
+	if endpoint != "" {
+		s3Opts = append(s3Opts, func(o *s3.Options) {
+			o.BaseEndpoint = &endpoint
+			o.UsePathStyle = true // MinIO requires path-style addressing
+		})
+	}
+
+	return &Client{
+		s3:     s3.NewFromConfig(cfg, s3Opts...),
+		bucket: bucket,
+	}, nil
+}
+
+// PutContent uploads string content to the given S3 key.
+func (c *Client) PutContent(ctx context.Context, key, content string) error {
+	if len(content) > maxContentBytes {
+		return ErrTooLarge
+	}
+	_, err := c.s3.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        &c.bucket,
+		Key:           &key,
+		Body:          bytes.NewReader([]byte(content)),
+		ContentLength: ptr(int64(len(content))),
+		ContentType:   ptr("text/plain; charset=utf-8"),
+	})
+	if err != nil {
+		return fmt.Errorf("put content %q: %w", key, err)
+	}
+	return nil
+}
+
+// GetContent downloads and returns the string content at the given S3 key.
+func (c *Client) GetContent(ctx context.Context, key string) (string, error) {
+	out, err := c.s3.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &c.bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		var nsk *s3types.NoSuchKey
+		if errors.As(err, &nsk) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("get content %q: %w", key, err)
+	}
+	defer out.Body.Close()
+
+	// Guard against oversized objects that shouldn't exist but could if
+	// someone wrote directly to the bucket bypassing the API.
+	limited := io.LimitReader(out.Body, maxContentBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("read content %q: %w", key, err)
+	}
+	if len(data) > maxContentBytes {
+		return "", ErrTooLarge
+	}
+	return string(data), nil
+}
+
+// DeleteContent removes the object at the given S3 key. Deleting a
+// non-existent key is not an error (S3 DeleteObject is idempotent).
+func (c *Client) DeleteContent(ctx context.Context, key string) error {
+	_, err := c.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: &c.bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		return fmt.Errorf("delete content %q: %w", key, err)
+	}
+	return nil
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,135 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pwntato/notoriousmcp/internal/store"
+)
+
+func uid() string { return fmt.Sprintf("%x", rand.Uint64()) }
+
+func newTestClient(t *testing.T) *store.Client {
+	t.Helper()
+	endpoint := os.Getenv("S3_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("S3_ENDPOINT not set; skipping integration test")
+	}
+	bucket := os.Getenv("S3_BUCKET")
+	if bucket == "" {
+		bucket = "notoriousmcp-local"
+	}
+	c, err := store.New(context.Background(), bucket, endpoint)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return c
+}
+
+func TestPutAndGet(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	key := "test/" + uid()
+	content := "hello, world"
+
+	if err := c.PutContent(ctx, key, content); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	got, err := c.GetContent(ctx, key)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != content {
+		t.Errorf("got %q want %q", got, content)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	c := newTestClient(t)
+	_, err := c.GetContent(context.Background(), "nonexistent/"+uid())
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	key := "test/" + uid()
+	if err := c.PutContent(ctx, key, "to be deleted"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := c.DeleteContent(ctx, key); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	_, err := c.GetContent(ctx, key)
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestDeleteIdempotent(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	// Deleting a non-existent key must not error
+	if err := c.DeleteContent(ctx, "nonexistent/"+uid()); err != nil {
+		t.Errorf("delete non-existent: expected nil, got %v", err)
+	}
+}
+
+func TestPutOverwrites(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	key := "test/" + uid()
+	if err := c.PutContent(ctx, key, "v1"); err != nil {
+		t.Fatalf("put v1: %v", err)
+	}
+	if err := c.PutContent(ctx, key, "v2"); err != nil {
+		t.Fatalf("put v2: %v", err)
+	}
+	got, err := c.GetContent(ctx, key)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != "v2" {
+		t.Errorf("got %q want v2", got)
+	}
+}
+
+func TestTooLarge(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	big := strings.Repeat("x", 1<<20+1)
+	err := c.PutContent(ctx, "test/"+uid(), big)
+	if !errors.Is(err, store.ErrTooLarge) {
+		t.Errorf("expected ErrTooLarge, got %v", err)
+	}
+}
+
+func TestRoundTripUnicode(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	key := "test/" + uid()
+	content := "# 日本語\n\nHello 🌍\n"
+	if err := c.PutContent(ctx, key, content); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	got, err := c.GetContent(ctx, key)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != content {
+		t.Errorf("unicode round-trip failed: got %q want %q", got, content)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -22,7 +22,7 @@ func newTestClient(t *testing.T) *store.Client {
 	}
 	bucket := os.Getenv("S3_BUCKET")
 	if bucket == "" {
-		bucket = "notoriousmcp-local"
+		t.Skip("S3_BUCKET not set; skipping integration test")
 	}
 	c, err := store.New(context.Background(), bucket, endpoint)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -36,17 +36,17 @@ func TestPutAndGet(t *testing.T) {
 	ctx := context.Background()
 
 	key := "test/" + uid()
-	content := "hello, world"
+	t.Cleanup(func() { _ = c.DeleteContent(context.Background(), key) })
 
-	if err := c.PutContent(ctx, key, content); err != nil {
+	if err := c.PutContent(ctx, key, "hello, world"); err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	got, err := c.GetContent(ctx, key)
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if got != content {
-		t.Errorf("got %q want %q", got, content)
+	if got != "hello, world" {
+		t.Errorf("got %q want %q", got, "hello, world")
 	}
 }
 
@@ -77,10 +77,7 @@ func TestDelete(t *testing.T) {
 
 func TestDeleteIdempotent(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
-
-	// Deleting a non-existent key must not error
-	if err := c.DeleteContent(ctx, "nonexistent/"+uid()); err != nil {
+	if err := c.DeleteContent(context.Background(), "nonexistent/"+uid()); err != nil {
 		t.Errorf("delete non-existent: expected nil, got %v", err)
 	}
 }
@@ -90,6 +87,8 @@ func TestPutOverwrites(t *testing.T) {
 	ctx := context.Background()
 
 	key := "test/" + uid()
+	t.Cleanup(func() { _ = c.DeleteContent(context.Background(), key) })
+
 	if err := c.PutContent(ctx, key, "v1"); err != nil {
 		t.Fatalf("put v1: %v", err)
 	}
@@ -107,10 +106,7 @@ func TestPutOverwrites(t *testing.T) {
 
 func TestTooLarge(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
-
-	big := strings.Repeat("x", 1<<20+1)
-	err := c.PutContent(ctx, "test/"+uid(), big)
+	err := c.PutContent(context.Background(), "test/"+uid(), strings.Repeat("x", 1<<20+1))
 	if !errors.Is(err, store.ErrTooLarge) {
 		t.Errorf("expected ErrTooLarge, got %v", err)
 	}
@@ -121,6 +117,8 @@ func TestRoundTripUnicode(t *testing.T) {
 	ctx := context.Background()
 
 	key := "test/" + uid()
+	t.Cleanup(func() { _ = c.DeleteContent(context.Background(), key) })
+
 	content := "# 日本語\n\nHello 🌍\n"
 	if err := c.PutContent(ctx, key, content); err != nil {
 		t.Fatalf("put: %v", err)


### PR DESCRIPTION
Closes #2
Closes #18

## Summary

### S3 store layer (`internal/store/`)

- `store.go` — `Client` wrapping aws-sdk-go-v2 S3; `UsePathStyle = true` for MinIO local dev compatibility
- `PutContent` — 1MB size guard enforced before upload; rejects with `ErrTooLarge`
- `GetContent` — maps `NoSuchKey` → `ErrNotFound`; `LimitReader` guard against oversized objects written directly to the bucket bypassing the API
- `DeleteContent` — idempotent (S3 `DeleteObject` succeeds on missing keys, unlike DynamoDB)
- `errors.go` — `ErrNotFound`, `ErrTooLarge` sentinels
- Tests cover: round-trip, not-found, delete, idempotent delete, overwrite, too-large rejection, unicode content; skipped without `S3_ENDPOINT`

### CI integration tests (`.github/workflows/test.yml`)

- DynamoDB Local runs as a GitHub Actions service container
- MinIO spun up via `docker run` (service containers don't support custom entrypoints well)
- Table and bucket initialized before `go test`
- `DYNAMODB_ENDPOINT`, `S3_ENDPOINT`, `TABLE_NAME`, `S3_BUCKET` injected so all integration tests run on every PR

## Test plan

- [ ] CI passes including integration tests
- [ ] `docker-compose up` + `S3_ENDPOINT=http://localhost:9000 S3_BUCKET=notoriousmcp-local go test ./internal/store/...` passes locally