### PR TITLE
feat: MCP server core — protocol handler and dynamic tool list (issue #5)

### DIFF
--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -1,17 +1,88 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
+	"os"
+	"strings"
+
+	"github.com/pwntato/notoriousmcp/internal/auth"
+	"github.com/pwntato/notoriousmcp/internal/db"
+	"github.com/pwntato/notoriousmcp/internal/handlers"
+	"github.com/pwntato/notoriousmcp/internal/store"
 )
 
 func main() {
+	ctx := context.Background()
+
+	tableName := envOrDefault("TABLE_NAME", "notoriousmcp")
+	dynamoEndpoint := os.Getenv("DYNAMODB_ENDPOINT")
+	dbClient, err := db.New(ctx, tableName, dynamoEndpoint)
+	if err != nil {
+		log.Fatalf("db: %v", err)
+	}
+
+	bucket := envOrDefault("S3_BUCKET", "notoriousmcp-local")
+	s3Endpoint := os.Getenv("S3_ENDPOINT")
+	storeClient, err := store.New(ctx, bucket, s3Endpoint)
+	if err != nil {
+		log.Fatalf("store: %v", err)
+	}
+
+	adminIDs := strings.Split(os.Getenv("ADMIN_GOOGLE_IDS"), ",")
+	tokenSecret := []byte(envOrDefault("TOKEN_SECRET", "local-dev-secret-key-at-least-32!!"))
+	authCfg := auth.Config{
+		ClientID:       envOrDefault("GOOGLE_CLIENT_ID", "local-client-id"),
+		ClientSecret:   envOrDefault("GOOGLE_CLIENT_SECRET", "local-client-secret"),
+		RedirectURL:    envOrDefault("REDIRECT_URL", "http://localhost:3000/auth/callback"),
+		AdminGoogleIDs: filterEmpty(adminIDs),
+		TokenSecret:    tokenSecret,
+		TrustProxy:     false,
+	}
+
+	authHandler := auth.New(authCfg, dbClient)
+	mcpHandler := handlers.New(dbClient, storeClient)
+
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"status":"ok"}`))
-	})
+	authHandler.RegisterRoutes(mux)
+	mcpHandler.RegisterRoutes(mux)
+
+	// Wrap the MCP endpoint with auth middleware.
+	// Auth routes (/auth/*, /.well-known/*) are public.
+	protected := auth.Middleware(authCfg, dbClient, mux)
+	final := publicRouter(mux, protected)
 
 	log.Println("listening on :3000")
-	log.Fatal(http.ListenAndServe(":3000", mux))
+	log.Fatal(http.ListenAndServe(":3000", final))
+}
+
+// publicRouter routes auth and well-known paths directly to mux (bypassing
+// middleware), and all other paths through the auth-protected handler.
+func publicRouter(public, protected http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/auth/") ||
+			strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			public.ServeHTTP(w, r)
+			return
+		}
+		protected.ServeHTTP(w, r)
+	})
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func filterEmpty(ss []string) []string {
+	var out []string
+	for _, s := range ss {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -59,6 +59,10 @@ func main() {
 
 // publicRouter routes auth and well-known paths directly to mux (bypassing
 // middleware), and all other paths through the auth-protected handler.
+// auth.RegisterRoutes only registers /auth/login and /auth/callback (with
+// trailing path components), so the /auth/ prefix check is correct — bare
+// /auth with no trailing slash falls through to the protected handler and
+// correctly returns 404.
 func publicRouter(public, protected http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/auth/") ||

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -77,6 +77,9 @@ func envOrDefault(key, def string) string {
 	return def
 }
 
+// filterEmpty removes empty strings. Needed because strings.Split("", ",") returns
+// [""] rather than [], so an unset ADMIN_GOOGLE_IDS env var must be cleaned before
+// passing to auth.Config.
 func filterEmpty(ss []string) []string {
 	var out []string
 	for _, s := range ss {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 
-	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
 )
 
 func handler(ctx context.Context, req events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -25,6 +25,12 @@ func UserFromContext(ctx context.Context) *models.User {
 	return u
 }
 
+// WithUserContext returns a copy of ctx with user injected as the authenticated
+// user. Intended for tests that bypass Middleware.
+func WithUserContext(ctx context.Context, user *models.User) context.Context {
+	return context.WithValue(ctx, userContextKey, user)
+}
+
 // Middleware wraps an http.Handler, enforcing token authentication on every
 // request. It validates the Bearer token, loads the user's current status from
 // DynamoDB (never trusting embedded token claims for authorization), and injects

--- a/internal/db/todos.go
+++ b/internal/db/todos.go
@@ -27,20 +27,20 @@ type todoListRecord struct {
 }
 
 type todoRecord struct {
-	PK         string             `dynamodbav:"PK"`
-	SK         string             `dynamodbav:"SK"`
-	GSI1PK     string             `dynamodbav:"GSI1PK"`
-	GSI1SK     string             `dynamodbav:"GSI1SK"`
-	ID         string             `dynamodbav:"ID"`
-	ListID     string             `dynamodbav:"ListID"`
-	UserID     string             `dynamodbav:"UserID"`
-	Text       string             `dynamodbav:"Text"`
-	Status     models.TodoStatus  `dynamodbav:"Status"`
-	DueDate    string             `dynamodbav:"DueDate,omitempty"`
-	Tags       []string           `dynamodbav:"Tags"`
-	Version    int                `dynamodbav:"Version"`
-	CreatedAt  string             `dynamodbav:"CreatedAt"`
-	ModifiedAt string             `dynamodbav:"ModifiedAt"`
+	PK         string            `dynamodbav:"PK"`
+	SK         string            `dynamodbav:"SK"`
+	GSI1PK     string            `dynamodbav:"GSI1PK"`
+	GSI1SK     string            `dynamodbav:"GSI1SK"`
+	ID         string            `dynamodbav:"ID"`
+	ListID     string            `dynamodbav:"ListID"`
+	UserID     string            `dynamodbav:"UserID"`
+	Text       string            `dynamodbav:"Text"`
+	Status     models.TodoStatus `dynamodbav:"Status"`
+	DueDate    string            `dynamodbav:"DueDate,omitempty"`
+	Tags       []string          `dynamodbav:"Tags"`
+	Version    int               `dynamodbav:"Version"`
+	CreatedAt  string            `dynamodbav:"CreatedAt"`
+	ModifiedAt string            `dynamodbav:"ModifiedAt"`
 }
 
 // GetTodoList retrieves a todo list by ID.

--- a/internal/handlers/export_test.go
+++ b/internal/handlers/export_test.go
@@ -1,0 +1,4 @@
+package handlers
+
+// CleanFilePath exposes cleanFilePath for unit testing.
+var CleanFilePath = cleanFilePath

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -1,0 +1,615 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/pwntato/notoriousmcp/internal/auth"
+	"github.com/pwntato/notoriousmcp/internal/db"
+	"github.com/pwntato/notoriousmcp/internal/handlers"
+	"github.com/pwntato/notoriousmcp/internal/models"
+	"github.com/pwntato/notoriousmcp/internal/store"
+)
+
+// ---- helpers ----
+
+type rpcReq struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type rpcResp struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// newUnitHandler builds an MCP handler that injects user into context via
+// auth.WithUserContext, bypassing auth.Middleware entirely. Safe for tests
+// that don't need DB or S3.
+func newUnitHandler(user *models.User) http.Handler {
+	h := handlers.New(nil, nil)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.WithUserContext(r.Context(), user)
+		mux.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func doMCPRequest(t *testing.T, h http.Handler, method string, params any) *rpcResp {
+	t.Helper()
+	body := rpcReq{JSONRPC: "2.0", ID: 1, Method: method, Params: params}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/mcp", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	var resp rpcResp
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response (body: %s): %v", w.Body.String(), err)
+	}
+	return &resp
+}
+
+// ---- unit tests: protocol layer ----
+
+func TestInitialize(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "initialize", nil)
+	if resp.Error != nil {
+		t.Fatalf("initialize error: %+v", resp.Error)
+	}
+
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		ServerInfo      struct {
+			Name string `json:"name"`
+		} `json:"serverInfo"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ProtocolVersion == "" {
+		t.Error("protocolVersion is empty")
+	}
+	if result.ServerInfo.Name == "" {
+		t.Error("serverInfo.name is empty")
+	}
+}
+
+func TestInvalidJSONRPCVersion(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	body := `{"jsonrpc":"1.0","id":1,"method":"initialize"}`
+	req := httptest.NewRequest("POST", "/mcp", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	var resp rpcResp
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Error == nil {
+		t.Fatal("expected JSON-RPC error for invalid version")
+	}
+	if resp.Error.Code != -32600 {
+		t.Errorf("code: got %d want -32600 (invalid request)", resp.Error.Code)
+	}
+}
+
+func TestParseError(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	req := httptest.NewRequest("POST", "/mcp", bytes.NewBufferString("{bad json"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	var resp rpcResp
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Error == nil {
+		t.Fatal("expected JSON-RPC error for bad JSON")
+	}
+	if resp.Error.Code != -32700 {
+		t.Errorf("code: got %d want -32700 (parse error)", resp.Error.Code)
+	}
+}
+
+func TestUnknownMethod(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "no/such/method", nil)
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown method")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("code: got %d want -32601 (method not found)", resp.Error.Code)
+	}
+}
+
+// ---- unit tests: tool list gating ----
+
+func TestToolsListUserRole(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/list", nil)
+	if resp.Error != nil {
+		t.Fatalf("tools/list error: %+v", resp.Error)
+	}
+
+	tools := parseToolsList(t, resp.Result)
+	// 4 notes + 3 todo-lists + 3 todos + 4 files = 14
+	if len(tools) != 14 {
+		t.Errorf("user role: got %d tools want 14", len(tools))
+	}
+	for _, name := range []string{"list_users", "update_user"} {
+		if toolsContain(tools, name) {
+			t.Errorf("user role must not see admin tool %q", name)
+		}
+	}
+	if toolsContain(tools, "check_status") {
+		t.Error("user role must not see check_status")
+	}
+}
+
+func TestToolsListAdminRole(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusAdmin}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/list", nil)
+	if resp.Error != nil {
+		t.Fatalf("tools/list error: %+v", resp.Error)
+	}
+
+	tools := parseToolsList(t, resp.Result)
+	// 14 user tools + 2 admin tools = 16
+	if len(tools) != 16 {
+		t.Errorf("admin role: got %d tools want 16", len(tools))
+	}
+	for _, name := range []string{"list_users", "update_user"} {
+		if !toolsContain(tools, name) {
+			t.Errorf("admin role must see tool %q", name)
+		}
+	}
+}
+
+func TestToolsListPendingRole(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusPending}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/list", nil)
+	if resp.Error != nil {
+		t.Fatalf("tools/list error: %+v", resp.Error)
+	}
+
+	tools := parseToolsList(t, resp.Result)
+	if len(tools) != 1 {
+		t.Errorf("pending role: got %d tools want 1", len(tools))
+	}
+	if !toolsContain(tools, "check_status") {
+		t.Error("pending role must have check_status")
+	}
+}
+
+func TestToolsListBannedRole(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusBanned}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/list", nil)
+	if resp.Error != nil {
+		t.Fatalf("tools/list error: %+v", resp.Error)
+	}
+
+	tools := parseToolsList(t, resp.Result)
+	if len(tools) != 1 || !toolsContain(tools, "check_status") {
+		t.Errorf("banned role: got %d tools, want exactly check_status", len(tools))
+	}
+}
+
+// ---- unit tests: check_status tool ----
+
+func TestCheckStatusPending(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusPending}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/call", map[string]any{
+		"name":      "check_status",
+		"arguments": map[string]any{},
+	})
+	if resp.Error != nil {
+		t.Fatalf("check_status error: %+v", resp.Error)
+	}
+	if text := firstContentText(t, resp.Result); text != "Your account is pending admin approval." {
+		t.Errorf("pending: got %q", text)
+	}
+}
+
+func TestCheckStatusBanned(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusBanned}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/call", map[string]any{
+		"name":      "check_status",
+		"arguments": map[string]any{},
+	})
+	if resp.Error != nil {
+		t.Fatalf("check_status error: %+v", resp.Error)
+	}
+	if text := firstContentText(t, resp.Result); text != "Your account has been banned." {
+		t.Errorf("banned: got %q", text)
+	}
+}
+
+// ---- unit tests: tool access control ----
+
+func TestUserCannotCallAdminTool(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/call", map[string]any{
+		"name":      "list_users",
+		"arguments": map[string]any{},
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error when user calls admin tool")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("code: got %d want -32601", resp.Error.Code)
+	}
+}
+
+func TestPendingCannotCallUserTool(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusPending}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/call", map[string]any{
+		"name":      "search_notes",
+		"arguments": map[string]any{},
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error when pending user calls search_notes")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("code: got %d want -32601", resp.Error.Code)
+	}
+}
+
+func TestToolsCallMissingName(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/call", map[string]any{
+		"arguments": map[string]any{},
+	})
+	// Empty name → method not found.
+	if resp.Error == nil {
+		t.Fatal("expected error for missing tool name")
+	}
+}
+
+// ---- integration tests (require DYNAMODB_ENDPOINT + S3_ENDPOINT) ----
+
+func newTestClients(t *testing.T) (*db.Client, *store.Client) {
+	t.Helper()
+	dynamoEndpoint := os.Getenv("DYNAMODB_ENDPOINT")
+	if dynamoEndpoint == "" {
+		t.Skip("DYNAMODB_ENDPOINT not set; skipping integration test")
+	}
+	s3Endpoint := os.Getenv("S3_ENDPOINT")
+	if s3Endpoint == "" {
+		t.Skip("S3_ENDPOINT not set; skipping integration test")
+	}
+	tableName := os.Getenv("TABLE_NAME")
+	if tableName == "" {
+		tableName = "notoriousmcp"
+	}
+	bucket := os.Getenv("S3_BUCKET")
+	if bucket == "" {
+		bucket = "notoriousmcp"
+	}
+	dbClient, err := db.New(context.Background(), tableName, dynamoEndpoint)
+	if err != nil {
+		t.Fatalf("new db client: %v", err)
+	}
+	storeClient, err := store.New(context.Background(), bucket, s3Endpoint)
+	if err != nil {
+		t.Fatalf("new store client: %v", err)
+	}
+	return dbClient, storeClient
+}
+
+var testSecret = []byte("test-secret-key-at-least-32-bytes!!")
+
+func saveIntegrationUser(t *testing.T, dbClient *db.Client, status models.UserStatus) *models.User {
+	t.Helper()
+	userID := newTestUserID()
+	u := &models.User{
+		UserID:    userID,
+		Email:     userID + "@example.com",
+		Name:      "Test " + userID,
+		Status:    status,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := dbClient.SaveUser(context.Background(), u); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+	return u
+}
+
+// newIntegrationHandler wraps the real handler with auth.Middleware so that
+// real Bearer tokens are validated against DynamoDB.
+func newIntegrationHandler(t *testing.T, dbClient *db.Client, storeClient *store.Client) http.Handler {
+	t.Helper()
+	h := handlers.New(dbClient, storeClient)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	cfg := auth.Config{
+		ClientID:     "x",
+		ClientSecret: "x",
+		RedirectURL:  "https://example.com/auth/callback",
+		TokenSecret:  testSecret,
+	}
+	return auth.Middleware(cfg, dbClient, mux)
+}
+
+func doIntegrationRequest(t *testing.T, h http.Handler, userID string, method string, params any) *rpcResp {
+	t.Helper()
+	token, err := auth.IssueAccessToken(testSecret, userID)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	body := rpcReq{JSONRPC: "2.0", ID: 1, Method: method, Params: params}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/mcp", bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	var resp rpcResp
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode (body: %s): %v", w.Body.String(), err)
+	}
+	return &resp
+}
+
+func TestIntegrationNoteCreateGetDelete(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	// Create.
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Integration Test Note",
+			"content": "hello world",
+			"tags":    []any{"test"},
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_note: %+v", resp.Error)
+	}
+	noteID := extractField(t, resp.Result, "id")
+
+	// Get.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "get_note",
+		"arguments": map[string]any{"note_id": noteID},
+	})
+	if resp.Error != nil {
+		t.Fatalf("get_note: %+v", resp.Error)
+	}
+	if content := extractField(t, resp.Result, "content"); content != "hello world" {
+		t.Errorf("content: got %q want \"hello world\"", content)
+	}
+
+	// Delete.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "delete_note",
+		"arguments": map[string]any{"note_id": noteID},
+	})
+	if resp.Error != nil {
+		t.Fatalf("delete_note: %+v", resp.Error)
+	}
+}
+
+func TestIntegrationTodoRoundTrip(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "save_todo_list",
+		"arguments": map[string]any{"title": "My List"},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_todo_list: %+v", resp.Error)
+	}
+	listID := extractField(t, resp.Result, "id")
+
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_todo",
+		"arguments": map[string]any{
+			"list_id": listID,
+			"text":    "buy milk",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_todo: %+v", resp.Error)
+	}
+	todoID := extractField(t, resp.Result, "id")
+
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "list_todos",
+		"arguments": map[string]any{"list_id": listID},
+	})
+	if resp.Error != nil {
+		t.Fatalf("list_todos: %+v", resp.Error)
+	}
+
+	doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "delete_todo",
+		"arguments": map[string]any{"list_id": listID, "todo_id": todoID},
+	})
+	doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "delete_todo_list",
+		"arguments": map[string]any{"list_id": listID},
+	})
+}
+
+func TestIntegrationFileRoundTrip(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	path := "integration/test-" + newTestUserID() + ".txt"
+
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_file",
+		"arguments": map[string]any{
+			"path":    path,
+			"content": "file contents",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_file: %+v", resp.Error)
+	}
+
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "get_file",
+		"arguments": map[string]any{"path": path},
+	})
+	if resp.Error != nil {
+		t.Fatalf("get_file: %+v", resp.Error)
+	}
+	if content := extractField(t, resp.Result, "content"); content != "file contents" {
+		t.Errorf("content: got %q", content)
+	}
+
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "delete_file",
+		"arguments": map[string]any{"path": path},
+	})
+	if resp.Error != nil {
+		t.Fatalf("delete_file: %+v", resp.Error)
+	}
+}
+
+func TestIntegrationAdminListUsers(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	admin := saveIntegrationUser(t, dbClient, models.StatusAdmin)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	resp := doIntegrationRequest(t, h, admin.UserID, "tools/call", map[string]any{
+		"name":      "list_users",
+		"arguments": map[string]any{},
+	})
+	if resp.Error != nil {
+		t.Fatalf("list_users: %+v", resp.Error)
+	}
+}
+
+func TestIntegrationAdminUpdateUser(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	admin := saveIntegrationUser(t, dbClient, models.StatusAdmin)
+	target := saveIntegrationUser(t, dbClient, models.StatusPending)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	resp := doIntegrationRequest(t, h, admin.UserID, "tools/call", map[string]any{
+		"name": "update_user",
+		"arguments": map[string]any{
+			"user_id": target.UserID,
+			"status":  "user",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("update_user: %+v", resp.Error)
+	}
+}
+
+// ---- test helpers ----
+
+type toolEntry struct {
+	Name string `json:"name"`
+}
+
+func parseToolsList(t *testing.T, raw json.RawMessage) []toolEntry {
+	t.Helper()
+	var result struct {
+		Tools []toolEntry `json:"tools"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("parse tools list: %v (raw: %s)", err, raw)
+	}
+	return result.Tools
+}
+
+func toolsContain(tools []toolEntry, name string) bool {
+	for _, tool := range tools {
+		if tool.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func firstContentText(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var result struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("parse content: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("no content items in result")
+	}
+	return result.Content[0].Text
+}
+
+// extractField parses the toolsCallResult Content[0].Text as JSON and returns the
+// value of the given top-level string field.
+func extractField(t *testing.T, raw json.RawMessage, field string) string {
+	t.Helper()
+	text := firstContentText(t, raw)
+	var m map[string]any
+	if err := json.Unmarshal([]byte(text), &m); err != nil {
+		t.Fatalf("parse content as JSON: %v (text: %s)", err, text)
+	}
+	v, _ := m[field].(string)
+	return v
+}
+
+func newTestUserID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -331,12 +331,21 @@ func TestSaveTodoInvalidStatus(t *testing.T) {
 }
 
 func TestNotificationsInitializedNoOp(t *testing.T) {
+	// notifications/initialized has no id (it's a one-way notification per MCP
+	// spec). The server must not send a response body — expect 204 No Content.
 	user := &models.User{UserID: "u1", Status: models.StatusUser}
 	h := newUnitHandler(user)
 
-	resp := doMCPRequest(t, h, "notifications/initialized", nil)
-	if resp.Error != nil {
-		t.Fatalf("notifications/initialized: expected no error, got %+v", resp.Error)
+	body := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	req := httptest.NewRequest("POST", "/mcp", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("notifications/initialized: got %d want 204", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("notifications/initialized: expected empty body, got %q", w.Body.String())
 	}
 }
 

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -411,6 +411,36 @@ func TestSaveFilePathSanitisation(t *testing.T) {
 	}
 }
 
+func TestCleanFilePath(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string // empty string means expect an error
+	}{
+		{"notes/foo.md", "notes/foo.md"},
+		{"../../etc/passwd", "etc/passwd"},   // traversal collapses, namespace stays under userID prefix
+		{"/absolute/path", "absolute/path"}, // leading slash stripped
+		{`back\slash`, "back/slash"},        // backslash normalized
+		{"a//b", "a/b"},                     // double slash collapsed
+		{"", ""},                            // empty → rejected
+		{".", ""},                           // dot → rejected
+		{"../", ""},                         // traversal-only → rejected
+	}
+	for _, tc := range cases {
+		got, err := handlers.CleanFilePath(tc.input)
+		if tc.want == "" {
+			if err == nil {
+				t.Errorf("cleanFilePath(%q): expected error, got %q", tc.input, got)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("cleanFilePath(%q): unexpected error: %v", tc.input, err)
+			} else if got != tc.want {
+				t.Errorf("cleanFilePath(%q): got %q want %q", tc.input, got, tc.want)
+			}
+		}
+	}
+}
+
 // ---- integration tests (require DYNAMODB_ENDPOINT + S3_ENDPOINT) ----
 
 func newTestClients(t *testing.T) (*db.Client, *store.Client) {

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -695,6 +695,18 @@ func TestIntegrationVersionConflict(t *testing.T) {
 	if !result.IsError {
 		t.Error("stale-version update: expected isError=true in result")
 	}
+
+	// Confirm the stale write was truly rejected: content must still be "v2".
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "get_note",
+		"arguments": map[string]any{"note_id": noteID},
+	})
+	if resp.Error != nil {
+		t.Fatalf("get_note after stale write: %+v", resp.Error)
+	}
+	if content := extractField(t, resp.Result, "content"); content != "v2" {
+		t.Errorf("note content after stale write: got %q want \"v2\"", content)
+	}
 }
 
 func TestIntegrationUserCannotCallAdminTool(t *testing.T) {

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -620,8 +620,8 @@ func TestIntegrationVersionConflict(t *testing.T) {
 	}
 	noteID := extractField(t, resp.Result, "id")
 
-	// Update once to advance version to 2.
-	doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+	// Update once to advance version to 2 — assert it succeeds.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
 		"name": "save_note",
 		"arguments": map[string]any{
 			"note_id": noteID,
@@ -630,6 +630,18 @@ func TestIntegrationVersionConflict(t *testing.T) {
 			"version": 2,
 		},
 	})
+	if resp.Error != nil {
+		t.Fatalf("save_note v2: %+v", resp.Error)
+	}
+	var v2result struct {
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(resp.Result, &v2result); err != nil {
+		t.Fatalf("unmarshal v2 result: %v", err)
+	}
+	if v2result.IsError {
+		t.Fatal("save_note v2 should succeed but got isError=true")
+	}
 
 	// Attempt to update with stale version 2 again — must get a conflict error.
 	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -471,14 +471,20 @@ func TestIntegrationTodoRoundTrip(t *testing.T) {
 		t.Fatalf("list_todos: %+v", resp.Error)
 	}
 
-	doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
 		"name":      "delete_todo",
 		"arguments": map[string]any{"list_id": listID, "todo_id": todoID},
 	})
-	doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+	if resp.Error != nil {
+		t.Fatalf("delete_todo: %+v", resp.Error)
+	}
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
 		"name":      "delete_todo_list",
 		"arguments": map[string]any{"list_id": listID},
 	})
+	if resp.Error != nil {
+		t.Fatalf("delete_todo_list: %+v", resp.Error)
+	}
 }
 
 func TestIntegrationFileRoundTrip(t *testing.T) {
@@ -548,6 +554,23 @@ func TestIntegrationAdminUpdateUser(t *testing.T) {
 	})
 	if resp.Error != nil {
 		t.Fatalf("update_user: %+v", resp.Error)
+	}
+}
+
+func TestIntegrationUserCannotCallAdminTool(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "list_users",
+		"arguments": map[string]any{},
+	})
+	if resp.Error == nil {
+		t.Fatal("user role must not be able to call list_users")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("code: got %d want -32601", resp.Error.Code)
 	}
 }
 

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -310,6 +310,26 @@ func TestToolsCallMissingName(t *testing.T) {
 	}
 }
 
+func TestSaveTodoInvalidStatus(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/call", map[string]any{
+		"name": "save_todo",
+		"arguments": map[string]any{
+			"list_id": "some-list",
+			"text":    "buy milk",
+			"status":  "not_a_real_status",
+		},
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error for invalid todo status in save_todo")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("code: got %d want -32602 (invalid params)", resp.Error.Code)
+	}
+}
+
 func TestNotificationsInitializedNoOp(t *testing.T) {
 	user := &models.User{UserID: "u1", Status: models.StatusUser}
 	h := newUnitHandler(user)
@@ -362,10 +382,10 @@ func TestSaveFilePathSanitisation(t *testing.T) {
 	invalid := []string{"", ".", "../", "../../etc/passwd/../.."}
 
 	for _, input := range invalid {
-		// Feed a path that after path.Clean + trim resolves to empty or ".".
-		// Only truly empty / dot results are rejected; traversal sequences that
-		// still produce a non-empty path (e.g. "../../etc/passwd") are cleaned
-		// and accepted (the result is "etc/passwd").
+		// These inputs resolve to empty or "." after path.Clean and are rejected.
+		// Inputs like "../../etc/passwd" are NOT rejected — they collapse to
+		// "etc/passwd" and are accepted, but remain safely scoped under the
+		// user's files/<userID>/ S3 prefix which is the actual namespace boundary.
 		user := &models.User{UserID: "u1", Status: models.StatusUser}
 		h := newUnitHandler(user)
 

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -302,9 +302,54 @@ func TestToolsCallMissingName(t *testing.T) {
 	resp := doMCPRequest(t, h, "tools/call", map[string]any{
 		"arguments": map[string]any{},
 	})
-	// Empty name → method not found.
 	if resp.Error == nil {
 		t.Fatal("expected error for missing tool name")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("code: got %d want -32601", resp.Error.Code)
+	}
+}
+
+func TestCheckStatusNotExposedToActiveUsers(t *testing.T) {
+	// check_status is only in the tool list for pending/banned users.
+	// Active users (user/admin) cannot call it — the tool list gates access.
+	for _, status := range []models.UserStatus{models.StatusUser, models.StatusAdmin} {
+		user := &models.User{UserID: "u1", Status: status}
+		h := newUnitHandler(user)
+
+		resp := doMCPRequest(t, h, "tools/call", map[string]any{
+			"name":      "check_status",
+			"arguments": map[string]any{},
+		})
+		if resp.Error == nil || resp.Error.Code != -32601 {
+			t.Errorf("status %s: expected -32601 method-not-found, got error=%v", status, resp.Error)
+		}
+	}
+}
+
+func TestSaveFilePathSanitisation(t *testing.T) {
+	// Test only the invalid cases — these are rejected before the db is touched,
+	// so a nil db client is fine.
+	invalid := []string{"", ".", "../", "../../etc/passwd/../.."}
+
+	for _, input := range invalid {
+		// Feed a path that after path.Clean + trim resolves to empty or ".".
+		// Only truly empty / dot results are rejected; traversal sequences that
+		// still produce a non-empty path (e.g. "../../etc/passwd") are cleaned
+		// and accepted (the result is "etc/passwd").
+		user := &models.User{UserID: "u1", Status: models.StatusUser}
+		h := newUnitHandler(user)
+
+		resp := doMCPRequest(t, h, "tools/call", map[string]any{
+			"name": "save_file",
+			"arguments": map[string]any{
+				"path":    input,
+				"content": "x",
+			},
+		})
+		if resp.Error == nil || resp.Error.Code != -32602 {
+			t.Errorf("path %q: expected -32602 invalid params, got error=%v", input, resp.Error)
+		}
 	}
 }
 
@@ -554,6 +599,60 @@ func TestIntegrationAdminUpdateUser(t *testing.T) {
 	})
 	if resp.Error != nil {
 		t.Fatalf("update_user: %+v", resp.Error)
+	}
+}
+
+func TestIntegrationVersionConflict(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	// Create a note.
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Conflict Test",
+			"content": "v1",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_note v1: %+v", resp.Error)
+	}
+	noteID := extractField(t, resp.Result, "id")
+
+	// Update once to advance version to 2.
+	doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"note_id": noteID,
+			"title":   "Conflict Test",
+			"content": "v2",
+			"version": 2,
+		},
+	})
+
+	// Attempt to update with stale version 2 again — must get a conflict error.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"note_id": noteID,
+			"title":   "Conflict Test",
+			"content": "stale",
+			"version": 2,
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %+v", resp.Error)
+	}
+	// The result should be an IsError tool result, not an RPC error.
+	var result struct {
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Error("stale-version update: expected isError=true in result")
 	}
 }
 

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -310,6 +310,35 @@ func TestToolsCallMissingName(t *testing.T) {
 	}
 }
 
+func TestNotificationsInitializedNoOp(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "notifications/initialized", nil)
+	if resp.Error != nil {
+		t.Fatalf("notifications/initialized: expected no error, got %+v", resp.Error)
+	}
+}
+
+func TestListTodosInvalidStatus(t *testing.T) {
+	user := &models.User{UserID: "u1", Status: models.StatusUser}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/call", map[string]any{
+		"name": "list_todos",
+		"arguments": map[string]any{
+			"list_id": "some-list",
+			"status":  "not_a_real_status",
+		},
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error for invalid todo status")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("code: got %d want -32602 (invalid params)", resp.Error.Code)
+	}
+}
+
 func TestCheckStatusNotExposedToActiveUsers(t *testing.T) {
 	// check_status is only in the tool list for pending/banned users.
 	// Active users (user/admin) cannot call it — the tool list gates access.

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -279,6 +279,20 @@ func parseOptionalTime(s string) (*time.Time, error) {
 	return &t, nil
 }
 
+// parseModifiedSince validates and normalises a user-supplied modified_since
+// string. Returns a normalised RFC3339 string suitable for DB key comparisons,
+// or an rpcError if the value is non-empty but unparseable.
+func parseModifiedSince(s string) (string, *rpcError) {
+	if s == "" {
+		return "", nil
+	}
+	t, err := parseOptionalTime(s)
+	if err != nil {
+		return "", &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	return t.UTC().Format(time.RFC3339), nil
+}
+
 // newID generates a random 16-byte hex ID.
 func newID() string {
 	b := make([]byte, 16)

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -28,7 +28,8 @@ type Handler struct {
 	store *store.Client
 }
 
-// New creates an MCP Handler.
+// New creates an MCP Handler. Passing nil for dbClient or storeClient is safe
+// only for unit tests that exercise code paths not reaching the DB or store.
 func New(dbClient *db.Client, storeClient *store.Client) *Handler {
 	return &Handler{db: dbClient, store: storeClient}
 }
@@ -107,9 +108,10 @@ func (h *Handler) dispatch(r *http.Request, user *models.User, method string, pa
 	case "initialize":
 		return h.handleInitialize(params)
 	case "notifications/initialized":
-		// No-op: clients send this after initialize per the MCP spec.
-		// Return an empty object so the response is valid JSON-RPC.
-		return map[string]any{}, nil
+		// MCP spec: notifications are one-way; the server must not send a
+		// response. Returning nil result produces {"result":null} which most
+		// clients ignore, and is preferable to {} which implies a schema.
+		return nil, nil
 	case "tools/list":
 		return h.handleToolsList(user)
 	case "tools/call":

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -90,6 +90,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// MCP notifications have no id field (or id: null). Per spec the server
+	// must not send a response for notifications — return 204 silently.
+	if isNotification(req.ID) {
+		h.dispatch(r, user, req.Method, req.Params) //nolint:errcheck // intentionally ignored
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	result, rpcErr := h.dispatch(r, user, req.Method, req.Params)
 	if rpcErr != nil {
 		writeError(w, req.ID, rpcErr.Code, rpcErr.Message)
@@ -103,15 +111,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// isNotification returns true when id is absent or null — the JSON-RPC 2.0
+// signal that a message is a one-way notification requiring no response.
+func isNotification(id json.RawMessage) bool {
+	return len(id) == 0 || string(id) == "null"
+}
+
 func (h *Handler) dispatch(r *http.Request, user *models.User, method string, params json.RawMessage) (any, *rpcError) {
 	switch method {
 	case "initialize":
 		return h.handleInitialize(params)
-	case "notifications/initialized":
-		// MCP spec: notifications are one-way; the server must not send a
-		// response. Returning nil result produces {"result":null} which most
-		// clients ignore, and is preferable to {} which implies a schema.
-		return nil, nil
 	case "tools/list":
 		return h.handleToolsList(user)
 	case "tools/call":

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -1,0 +1,298 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/pwntato/notoriousmcp/internal/auth"
+	"github.com/pwntato/notoriousmcp/internal/db"
+	"github.com/pwntato/notoriousmcp/internal/models"
+	"github.com/pwntato/notoriousmcp/internal/store"
+)
+
+const (
+	mcpProtocolVersion = "2024-11-05"
+	serverName         = "notoriousmcp"
+	serverVersion      = "0.1.0"
+)
+
+// Handler is the MCP protocol handler.
+type Handler struct {
+	db    *db.Client
+	store *store.Client
+}
+
+// New creates an MCP Handler.
+func New(dbClient *db.Client, storeClient *store.Client) *Handler {
+	return &Handler{db: dbClient, store: storeClient}
+}
+
+// RegisterRoutes wires the MCP endpoint onto the given mux.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /mcp", h.ServeHTTP)
+}
+
+// JSON-RPC 2.0 types.
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+const (
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternalError  = -32603
+)
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req rpcRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, nil, codeParseError, "parse error")
+		return
+	}
+	if req.JSONRPC != "2.0" {
+		writeError(w, req.ID, codeInvalidRequest, "jsonrpc must be \"2.0\"")
+		return
+	}
+
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, req.ID, codeInternalError, "internal error")
+		return
+	}
+
+	result, rpcErr := h.dispatch(r, user, req.Method, req.Params)
+	if rpcErr != nil {
+		writeError(w, req.ID, rpcErr.Code, rpcErr.Message)
+		return
+	}
+
+	resp := rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: result}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("mcp: encode response: %v", err)
+	}
+}
+
+func (h *Handler) dispatch(r *http.Request, user *models.User, method string, params json.RawMessage) (any, *rpcError) {
+	switch method {
+	case "initialize":
+		return h.handleInitialize(params)
+	case "tools/list":
+		return h.handleToolsList(user)
+	case "tools/call":
+		return h.handleToolsCall(r, user, params)
+	default:
+		return nil, &rpcError{Code: codeMethodNotFound, Message: fmt.Sprintf("method not found: %s", method)}
+	}
+}
+
+// MCP initialize response types.
+
+type initResult struct {
+	ProtocolVersion string       `json:"protocolVersion"`
+	Capabilities    capabilities `json:"capabilities"`
+	ServerInfo      serverInfo   `json:"serverInfo"`
+}
+
+type capabilities struct {
+	Tools toolsCap `json:"tools"`
+}
+
+type toolsCap struct {
+	ListChanged bool `json:"listChanged"`
+}
+
+type serverInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (h *Handler) handleInitialize(_ json.RawMessage) (any, *rpcError) {
+	return initResult{
+		ProtocolVersion: mcpProtocolVersion,
+		Capabilities:    capabilities{Tools: toolsCap{ListChanged: false}},
+		ServerInfo:      serverInfo{Name: serverName, Version: serverVersion},
+	}, nil
+}
+
+// tools/list
+
+type toolsListResult struct {
+	Tools []toolDef `json:"tools"`
+}
+
+func (h *Handler) handleToolsList(user *models.User) (any, *rpcError) {
+	return toolsListResult{Tools: toolsForUser(user)}, nil
+}
+
+// tools/call
+
+type toolsCallParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+type toolsCallResult struct {
+	Content []toolContent `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+type toolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func (h *Handler) handleToolsCall(r *http.Request, user *models.User, params json.RawMessage) (any, *rpcError) {
+	var p toolsCallParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: "invalid params"}
+	}
+	if p.Arguments == nil {
+		p.Arguments = map[string]any{}
+	}
+
+	allowed := toolsForUser(user)
+	found := false
+	for _, t := range allowed {
+		if t.Name == p.Name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, &rpcError{Code: codeMethodNotFound, Message: fmt.Sprintf("unknown tool: %s", p.Name)}
+	}
+
+	return h.callTool(r.Context(), user, p.Name, p.Arguments)
+}
+
+// textResult wraps plain text output in an MCP content block.
+func textResult(text string) (*toolsCallResult, *rpcError) {
+	return &toolsCallResult{Content: []toolContent{{Type: "text", Text: text}}}, nil
+}
+
+// errorResult wraps an error message in an MCP content block with IsError=true.
+func errorResult(text string) (*toolsCallResult, *rpcError) {
+	return &toolsCallResult{
+		Content: []toolContent{{Type: "text", Text: text}},
+		IsError: true,
+	}, nil
+}
+
+// jsonResult serialises v as pretty JSON inside an MCP content block.
+func jsonResult(v any) (*toolsCallResult, *rpcError) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+	return &toolsCallResult{Content: []toolContent{{Type: "text", Text: string(b)}}}, nil
+}
+
+func writeError(w http.ResponseWriter, id json.RawMessage, code int, message string) {
+	resp := rpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcError{Code: code, Message: message},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// strArg extracts a required string argument.
+func strArg(args map[string]any, key string) (string, error) {
+	v, ok := args[key]
+	if !ok {
+		return "", fmt.Errorf("missing required argument %q", key)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("argument %q must be a string", key)
+	}
+	return s, nil
+}
+
+// strArgOpt extracts an optional string argument.
+func strArgOpt(args map[string]any, key string) string {
+	v, ok := args[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// strSliceArgOpt extracts an optional []string argument.
+func strSliceArgOpt(args map[string]any, key string) []string {
+	v, ok := args[key]
+	if !ok {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// parseOptionalTime parses an ISO 8601 timestamp string, returning nil if empty.
+func parseOptionalTime(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timestamp %q: must be RFC3339", s)
+	}
+	return &t, nil
+}
+
+// newID generates a random 16-byte hex ID.
+func newID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand unavailable: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
+// dbErrResult translates common db errors to user-facing error results.
+func dbErrResult(err error) (*toolsCallResult, *rpcError) {
+	if errors.Is(err, db.ErrNotFound) {
+		return errorResult("not found")
+	}
+	if errors.Is(err, db.ErrVersionConflict) {
+		return errorResult("version conflict: reload and retry")
+	}
+	log.Printf("mcp: db error: %v", err)
+	return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+}

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -285,6 +285,21 @@ func newID() string {
 	return hex.EncodeToString(b)
 }
 
+// versionArg reads the optional "version" argument as int.
+func versionArg(args map[string]any) int {
+	v, ok := args["version"]
+	if !ok {
+		return 0
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	}
+	return 0
+}
+
 // dbErrResult translates common db errors to user-facing error results.
 func dbErrResult(err error) (*toolsCallResult, *rpcError) {
 	if errors.Is(err, db.ErrNotFound) {

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -106,6 +106,10 @@ func (h *Handler) dispatch(r *http.Request, user *models.User, method string, pa
 	switch method {
 	case "initialize":
 		return h.handleInitialize(params)
+	case "notifications/initialized":
+		// No-op: clients send this after initialize per the MCP spec.
+		// Return an empty object so the response is valid JSON-RPC.
+		return map[string]any{}, nil
 	case "tools/list":
 		return h.handleToolsList(user)
 	case "tools/call":

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -67,7 +67,12 @@ const (
 	codeInternalError  = -32603
 )
 
+// maxRequestBytes caps the MCP request body to slightly above the 1MB content
+// limit so a single large tool call is accepted while unbounded payloads are not.
+const maxRequestBytes = 2 << 20 // 2MB
+
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
 	var req rpcRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, nil, codeParseError, "parse error")
@@ -146,7 +151,7 @@ type toolsListResult struct {
 }
 
 func (h *Handler) handleToolsList(user *models.User) (any, *rpcError) {
-	return toolsListResult{Tools: toolsForUser(user)}, nil
+	return toolsListResult{Tools: toolDefsFor(h.toolsForUser(user))}, nil
 }
 
 // tools/call
@@ -175,19 +180,13 @@ func (h *Handler) handleToolsCall(r *http.Request, user *models.User, params jso
 		p.Arguments = map[string]any{}
 	}
 
-	allowed := toolsForUser(user)
-	found := false
+	allowed := h.toolsForUser(user)
 	for _, t := range allowed {
-		if t.Name == p.Name {
-			found = true
-			break
+		if t.def.Name == p.Name {
+			return t.fn(r.Context(), user, p.Arguments)
 		}
 	}
-	if !found {
-		return nil, &rpcError{Code: codeMethodNotFound, Message: fmt.Sprintf("unknown tool: %s", p.Name)}
-	}
-
-	return h.callTool(r.Context(), user, p.Name, p.Arguments)
+	return nil, &rpcError{Code: codeMethodNotFound, Message: fmt.Sprintf("unknown tool: %s", p.Name)}
 }
 
 // textResult wraps plain text output in an MCP content block.

--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -354,9 +354,8 @@ func (h *Handler) adminTools() []registeredTool {
 				},
 			},
 			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
-				return h.handleUpdateUser(ctx, args)
+				return h.handleUpdateUser(ctx, user, args)
 			},
 		},
 	}
 }
-

--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -241,7 +241,7 @@ var (
 	}
 )
 
-// userTools are the 13 tools available to all active users.
+// userTools are the 14 tools available to all active users.
 var userTools = []toolDef{
 	toolSearchNotes,
 	toolGetNote,

--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -63,6 +63,7 @@ func toolDefsFor(tools []registeredTool) []toolDef {
 	}
 	return defs
 }
+
 // checkStatusTool returns the single-element slice containing the check_status
 // tool — the only tool exposed to pending/banned users. A dedicated helper
 // avoids indexing into a slice by position.

--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -51,7 +51,7 @@ func (h *Handler) toolsForUser(user *models.User) []registeredTool {
 		return append(h.userTools(), h.adminTools()...)
 	default:
 		// pending or banned — check_status only
-		return []registeredTool{h.statusTools()[0]}
+		return h.checkStatusTool()
 	}
 }
 
@@ -63,10 +63,10 @@ func toolDefsFor(tools []registeredTool) []toolDef {
 	}
 	return defs
 }
-
-
-// statusTools returns the tool list for pending/banned users.
-func (h *Handler) statusTools() []registeredTool {
+// checkStatusTool returns the single-element slice containing the check_status
+// tool — the only tool exposed to pending/banned users. A dedicated helper
+// avoids indexing into a slice by position.
+func (h *Handler) checkStatusTool() []registeredTool {
 	return []registeredTool{
 		{
 			def: toolDef{

--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"log"
 
 	"github.com/pwntato/notoriousmcp/internal/models"
 )
@@ -65,19 +64,6 @@ func toolDefsFor(tools []registeredTool) []toolDef {
 	return defs
 }
 
-// callTool finds the named tool in allowed and calls it. The allowed list must
-// already have been checked for access control before calling this function —
-// the lookup here is a second-pass dispatch on the same slice, not a new gate.
-func callTool(ctx context.Context, user *models.User, name string, allowed []registeredTool, args map[string]any) (*toolsCallResult, *rpcError) {
-	for _, t := range allowed {
-		if t.def.Name == name {
-			return t.fn(ctx, user, args)
-		}
-	}
-	// Unreachable: handleToolsCall already verified name is in allowed.
-	log.Printf("mcp: callTool: %q not found in allowed list (should not happen)", name)
-	return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
-}
 
 // statusTools returns the tool list for pending/banned users.
 func (h *Handler) statusTools() []registeredTool {

--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -2,16 +2,16 @@ package handlers
 
 import (
 	"context"
-	"fmt"
+	"log"
 
 	"github.com/pwntato/notoriousmcp/internal/models"
 )
 
 // toolDef is the MCP tool definition returned by tools/list.
 type toolDef struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	InputSchema schema   `json:"inputSchema"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InputSchema schema `json:"inputSchema"`
 }
 
 type schema struct {
@@ -31,294 +31,345 @@ type items struct {
 	Type string `json:"type"`
 }
 
-var (
-	toolCheckStatus = toolDef{
-		Name:        "check_status",
-		Description: "Check your account status.",
-		InputSchema: schema{Type: "object"},
-	}
+// toolFn is the handler signature for a single tool call.
+type toolFn func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError)
 
-	toolSearchNotes = toolDef{
-		Name:        "search_notes",
-		Description: "List note metadata, optionally filtered by modified-since timestamp.",
-		InputSchema: schema{
-			Type: "object",
-			Properties: map[string]property{
-				"modified_since": {Type: "string", Description: "ISO 8601 timestamp; only return notes modified after this time."},
-			},
-		},
-	}
-
-	toolGetNote = toolDef{
-		Name:        "get_note",
-		Description: "Get note metadata and full content by ID.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"note_id"},
-			Properties: map[string]property{
-				"note_id": {Type: "string", Description: "Note ID."},
-			},
-		},
-	}
-
-	toolSaveNote = toolDef{
-		Name:        "save_note",
-		Description: "Create or update a note. Omit note_id to create. On update, version must match the current stored version.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"title", "content"},
-			Properties: map[string]property{
-				"note_id": {Type: "string", Description: "Note ID (omit to create)."},
-				"title":   {Type: "string", Description: "Note title."},
-				"content": {Type: "string", Description: "Note body (max 1MB)."},
-				"tags":    {Type: "array", Description: "Tag list.", Items: &items{Type: "string"}},
-				"version": {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
-			},
-		},
-	}
-
-	toolDeleteNote = toolDef{
-		Name:        "delete_note",
-		Description: "Delete a note and its content.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"note_id"},
-			Properties: map[string]property{
-				"note_id": {Type: "string", Description: "Note ID."},
-			},
-		},
-	}
-
-	toolListTodoLists = toolDef{
-		Name:        "list_todo_lists",
-		Description: "List all todo lists.",
-		InputSchema: schema{Type: "object"},
-	}
-
-	toolSaveTodoList = toolDef{
-		Name:        "save_todo_list",
-		Description: "Create or update a todo list. Omit list_id to create.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"title"},
-			Properties: map[string]property{
-				"list_id": {Type: "string", Description: "List ID (omit to create)."},
-				"title":   {Type: "string", Description: "List title."},
-				"tags":    {Type: "array", Description: "Tag list.", Items: &items{Type: "string"}},
-				"version": {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
-			},
-		},
-	}
-
-	toolDeleteTodoList = toolDef{
-		Name:        "delete_todo_list",
-		Description: "Delete a todo list. Does not cascade-delete its todos.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"list_id"},
-			Properties: map[string]property{
-				"list_id": {Type: "string", Description: "List ID."},
-			},
-		},
-	}
-
-	toolListTodos = toolDef{
-		Name:        "list_todos",
-		Description: "List todos in a list, optionally filtered by status or modified-since.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"list_id"},
-			Properties: map[string]property{
-				"list_id":        {Type: "string", Description: "List ID."},
-				"status":         {Type: "string", Description: "Filter by status.", Enum: []string{"pending", "in_progress", "done"}},
-				"modified_since": {Type: "string", Description: "ISO 8601 timestamp; only return todos modified after this time."},
-			},
-		},
-	}
-
-	toolSaveTodo = toolDef{
-		Name:        "save_todo",
-		Description: "Create or update a todo item. Omit todo_id to create.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"list_id", "text"},
-			Properties: map[string]property{
-				"list_id":  {Type: "string", Description: "List ID."},
-				"todo_id":  {Type: "string", Description: "Todo ID (omit to create)."},
-				"text":     {Type: "string", Description: "Todo item text."},
-				"status":   {Type: "string", Description: "Todo status.", Enum: []string{"pending", "in_progress", "done"}},
-				"due_date": {Type: "string", Description: "Due date (RFC3339)."},
-				"tags":     {Type: "array", Description: "Tag list.", Items: &items{Type: "string"}},
-				"version":  {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
-			},
-		},
-	}
-
-	toolDeleteTodo = toolDef{
-		Name:        "delete_todo",
-		Description: "Delete a todo item.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"list_id", "todo_id"},
-			Properties: map[string]property{
-				"list_id": {Type: "string", Description: "List ID."},
-				"todo_id": {Type: "string", Description: "Todo ID."},
-			},
-		},
-	}
-
-	toolListFiles = toolDef{
-		Name:        "list_files",
-		Description: "List file metadata, optionally filtered by modified-since timestamp.",
-		InputSchema: schema{
-			Type: "object",
-			Properties: map[string]property{
-				"modified_since": {Type: "string", Description: "ISO 8601 timestamp; only return files modified after this time."},
-			},
-		},
-	}
-
-	toolGetFile = toolDef{
-		Name:        "get_file",
-		Description: "Get file metadata and full content by path.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"path"},
-			Properties: map[string]property{
-				"path": {Type: "string", Description: "File path."},
-			},
-		},
-	}
-
-	toolSaveFile = toolDef{
-		Name:        "save_file",
-		Description: "Create or update a file. On update, version must match the current stored version.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"path", "content"},
-			Properties: map[string]property{
-				"path":    {Type: "string", Description: "File path."},
-				"content": {Type: "string", Description: "File content (max 1MB)."},
-				"version": {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
-			},
-		},
-	}
-
-	toolDeleteFile = toolDef{
-		Name:        "delete_file",
-		Description: "Delete a file and its content.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"path"},
-			Properties: map[string]property{
-				"path": {Type: "string", Description: "File path."},
-			},
-		},
-	}
-
-	toolListUsers = toolDef{
-		Name:        "list_users",
-		Description: "List users, optionally filtered by status.",
-		InputSchema: schema{
-			Type: "object",
-			Properties: map[string]property{
-				"status": {Type: "string", Description: "Filter by status.", Enum: []string{"pending", "user", "admin", "banned"}},
-			},
-		},
-	}
-
-	toolUpdateUser = toolDef{
-		Name:        "update_user",
-		Description: "Update a user's status.",
-		InputSchema: schema{
-			Type:     "object",
-			Required: []string{"user_id", "status"},
-			Properties: map[string]property{
-				"user_id": {Type: "string", Description: "User ID."},
-				"status":  {Type: "string", Description: "New status.", Enum: []string{"pending", "user", "admin", "banned"}},
-			},
-		},
-	}
-)
-
-// userTools are the 14 tools available to all active users.
-var userTools = []toolDef{
-	toolSearchNotes,
-	toolGetNote,
-	toolSaveNote,
-	toolDeleteNote,
-	toolListTodoLists,
-	toolSaveTodoList,
-	toolDeleteTodoList,
-	toolListTodos,
-	toolSaveTodo,
-	toolDeleteTodo,
-	toolListFiles,
-	toolGetFile,
-	toolSaveFile,
-	toolDeleteFile,
+// registeredTool pairs the MCP definition with its handler. Using a single
+// slice of registeredTool as the source of truth means the access-control gate
+// in handleToolsCall and the dispatch are always in sync — adding a tool in one
+// place automatically covers both.
+type registeredTool struct {
+	def toolDef
+	fn  toolFn
 }
 
-// adminOnlyTools are the 2 additional tools available to admins.
-var adminOnlyTools = []toolDef{
-	toolListUsers,
-	toolUpdateUser,
-}
-
-// toolsForUser returns the tool list appropriate for the given user's role.
-func toolsForUser(user *models.User) []toolDef {
+// toolsForUser returns the registered tools appropriate for the given user's role.
+func (h *Handler) toolsForUser(user *models.User) []registeredTool {
 	switch user.Status {
 	case models.StatusUser:
-		return userTools
+		return h.userTools()
 	case models.StatusAdmin:
-		tools := make([]toolDef, len(userTools)+len(adminOnlyTools))
-		copy(tools, userTools)
-		copy(tools[len(userTools):], adminOnlyTools)
-		return tools
+		return append(h.userTools(), h.adminTools()...)
 	default:
 		// pending or banned — check_status only
-		return []toolDef{toolCheckStatus}
+		return []registeredTool{h.statusTools()[0]}
 	}
 }
 
-// callTool dispatches to the appropriate tool handler.
-func (h *Handler) callTool(ctx context.Context, user *models.User, name string, args map[string]any) (*toolsCallResult, *rpcError) {
-	switch name {
-	case "check_status":
-		return handleCheckStatus(user)
-	case "search_notes":
-		return h.handleSearchNotes(ctx, user, args)
-	case "get_note":
-		return h.handleGetNote(ctx, user, args)
-	case "save_note":
-		return h.handleSaveNote(ctx, user, args)
-	case "delete_note":
-		return h.handleDeleteNote(ctx, user, args)
-	case "list_todo_lists":
-		return h.handleListTodoLists(ctx, user, args)
-	case "save_todo_list":
-		return h.handleSaveTodoList(ctx, user, args)
-	case "delete_todo_list":
-		return h.handleDeleteTodoList(ctx, user, args)
-	case "list_todos":
-		return h.handleListTodos(ctx, user, args)
-	case "save_todo":
-		return h.handleSaveTodo(ctx, user, args)
-	case "delete_todo":
-		return h.handleDeleteTodo(ctx, user, args)
-	case "list_files":
-		return h.handleListFiles(ctx, user, args)
-	case "get_file":
-		return h.handleGetFile(ctx, user, args)
-	case "save_file":
-		return h.handleSaveFile(ctx, user, args)
-	case "delete_file":
-		return h.handleDeleteFile(ctx, user, args)
-	case "list_users":
-		return h.handleListUsers(ctx, args)
-	case "update_user":
-		return h.handleUpdateUser(ctx, args)
-	default:
-		return nil, &rpcError{Code: codeMethodNotFound, Message: fmt.Sprintf("unknown tool: %s", name)}
+// toolDefsFor extracts the []toolDef slice from a []registeredTool, for tools/list.
+func toolDefsFor(tools []registeredTool) []toolDef {
+	defs := make([]toolDef, len(tools))
+	for i, t := range tools {
+		defs[i] = t.def
+	}
+	return defs
+}
+
+// callTool finds the named tool in allowed and calls it. The allowed list must
+// already have been checked for access control before calling this function —
+// the lookup here is a second-pass dispatch on the same slice, not a new gate.
+func callTool(ctx context.Context, user *models.User, name string, allowed []registeredTool, args map[string]any) (*toolsCallResult, *rpcError) {
+	for _, t := range allowed {
+		if t.def.Name == name {
+			return t.fn(ctx, user, args)
+		}
+	}
+	// Unreachable: handleToolsCall already verified name is in allowed.
+	log.Printf("mcp: callTool: %q not found in allowed list (should not happen)", name)
+	return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+}
+
+// statusTools returns the tool list for pending/banned users.
+func (h *Handler) statusTools() []registeredTool {
+	return []registeredTool{
+		{
+			def: toolDef{
+				Name:        "check_status",
+				Description: "Check your account status.",
+				InputSchema: schema{Type: "object"},
+			},
+			fn: func(_ context.Context, user *models.User, _ map[string]any) (*toolsCallResult, *rpcError) {
+				return handleCheckStatus(user)
+			},
+		},
 	}
 }
+
+// userTools returns the 14 tools available to all active users.
+func (h *Handler) userTools() []registeredTool {
+	return []registeredTool{
+		{
+			def: toolDef{
+				Name:        "search_notes",
+				Description: "List note metadata, optionally filtered by modified-since timestamp.",
+				InputSchema: schema{
+					Type: "object",
+					Properties: map[string]property{
+						"modified_since": {Type: "string", Description: "ISO 8601 timestamp; only return notes modified after this time."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleSearchNotes(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "get_note",
+				Description: "Get note metadata and full content by ID.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"note_id"},
+					Properties: map[string]property{
+						"note_id": {Type: "string", Description: "Note ID."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleGetNote(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "save_note",
+				Description: "Create or update a note. Omit note_id to create. On update, version must match the current stored version.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"title", "content"},
+					Properties: map[string]property{
+						"note_id": {Type: "string", Description: "Note ID (omit to create)."},
+						"title":   {Type: "string", Description: "Note title."},
+						"content": {Type: "string", Description: "Note body (max 1MB)."},
+						"tags":    {Type: "array", Description: "Tag list.", Items: &items{Type: "string"}},
+						"version": {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleSaveNote(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "delete_note",
+				Description: "Delete a note and its content.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"note_id"},
+					Properties: map[string]property{
+						"note_id": {Type: "string", Description: "Note ID."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleDeleteNote(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "list_todo_lists",
+				Description: "List all todo lists.",
+				InputSchema: schema{Type: "object"},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleListTodoLists(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "save_todo_list",
+				Description: "Create or update a todo list. Omit list_id to create.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"title"},
+					Properties: map[string]property{
+						"list_id": {Type: "string", Description: "List ID (omit to create)."},
+						"title":   {Type: "string", Description: "List title."},
+						"tags":    {Type: "array", Description: "Tag list.", Items: &items{Type: "string"}},
+						"version": {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleSaveTodoList(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "delete_todo_list",
+				Description: "Delete a todo list. Does not cascade-delete its todos.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"list_id"},
+					Properties: map[string]property{
+						"list_id": {Type: "string", Description: "List ID."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleDeleteTodoList(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "list_todos",
+				Description: "List todos in a list, optionally filtered by status or modified-since.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"list_id"},
+					Properties: map[string]property{
+						"list_id":        {Type: "string", Description: "List ID."},
+						"status":         {Type: "string", Description: "Filter by status.", Enum: []string{"pending", "in_progress", "done"}},
+						"modified_since": {Type: "string", Description: "ISO 8601 timestamp; only return todos modified after this time."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleListTodos(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "save_todo",
+				Description: "Create or update a todo item. Omit todo_id to create.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"list_id", "text"},
+					Properties: map[string]property{
+						"list_id":  {Type: "string", Description: "List ID."},
+						"todo_id":  {Type: "string", Description: "Todo ID (omit to create)."},
+						"text":     {Type: "string", Description: "Todo item text."},
+						"status":   {Type: "string", Description: "Todo status.", Enum: []string{"pending", "in_progress", "done"}},
+						"due_date": {Type: "string", Description: "Due date (RFC3339)."},
+						"tags":     {Type: "array", Description: "Tag list.", Items: &items{Type: "string"}},
+						"version":  {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleSaveTodo(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "delete_todo",
+				Description: "Delete a todo item.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"list_id", "todo_id"},
+					Properties: map[string]property{
+						"list_id": {Type: "string", Description: "List ID."},
+						"todo_id": {Type: "string", Description: "Todo ID."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleDeleteTodo(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "list_files",
+				Description: "List file metadata, optionally filtered by modified-since timestamp.",
+				InputSchema: schema{
+					Type: "object",
+					Properties: map[string]property{
+						"modified_since": {Type: "string", Description: "ISO 8601 timestamp; only return files modified after this time."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleListFiles(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "get_file",
+				Description: "Get file metadata and full content by path.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"path"},
+					Properties: map[string]property{
+						"path": {Type: "string", Description: "File path."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleGetFile(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "save_file",
+				Description: "Create or update a file. On update, version must match the current stored version.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"path", "content"},
+					Properties: map[string]property{
+						"path":    {Type: "string", Description: "File path."},
+						"content": {Type: "string", Description: "File content (max 1MB)."},
+						"version": {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleSaveFile(ctx, user, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "delete_file",
+				Description: "Delete a file and its content.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"path"},
+					Properties: map[string]property{
+						"path": {Type: "string", Description: "File path."},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleDeleteFile(ctx, user, args)
+			},
+		},
+	}
+}
+
+// adminTools returns the 2 tools available only to admins.
+func (h *Handler) adminTools() []registeredTool {
+	return []registeredTool{
+		{
+			def: toolDef{
+				Name:        "list_users",
+				Description: "List users, optionally filtered by status.",
+				InputSchema: schema{
+					Type: "object",
+					Properties: map[string]property{
+						"status": {Type: "string", Description: "Filter by status.", Enum: []string{"pending", "user", "admin", "banned"}},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleListUsers(ctx, args)
+			},
+		},
+		{
+			def: toolDef{
+				Name:        "update_user",
+				Description: "Update a user's status.",
+				InputSchema: schema{
+					Type:     "object",
+					Required: []string{"user_id", "status"},
+					Properties: map[string]property{
+						"user_id": {Type: "string", Description: "User ID."},
+						"status":  {Type: "string", Description: "New status.", Enum: []string{"pending", "user", "admin", "banned"}},
+					},
+				},
+			},
+			fn: func(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+				return h.handleUpdateUser(ctx, args)
+			},
+		},
+	}
+}
+

--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -1,0 +1,324 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pwntato/notoriousmcp/internal/models"
+)
+
+// toolDef is the MCP tool definition returned by tools/list.
+type toolDef struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	InputSchema schema   `json:"inputSchema"`
+}
+
+type schema struct {
+	Type       string              `json:"type"`
+	Properties map[string]property `json:"properties,omitempty"`
+	Required   []string            `json:"required,omitempty"`
+}
+
+type property struct {
+	Type        string   `json:"type"`
+	Description string   `json:"description"`
+	Enum        []string `json:"enum,omitempty"`
+	Items       *items   `json:"items,omitempty"`
+}
+
+type items struct {
+	Type string `json:"type"`
+}
+
+var (
+	toolCheckStatus = toolDef{
+		Name:        "check_status",
+		Description: "Check your account status.",
+		InputSchema: schema{Type: "object"},
+	}
+
+	toolSearchNotes = toolDef{
+		Name:        "search_notes",
+		Description: "List note metadata, optionally filtered by modified-since timestamp.",
+		InputSchema: schema{
+			Type: "object",
+			Properties: map[string]property{
+				"modified_since": {Type: "string", Description: "ISO 8601 timestamp; only return notes modified after this time."},
+			},
+		},
+	}
+
+	toolGetNote = toolDef{
+		Name:        "get_note",
+		Description: "Get note metadata and full content by ID.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"note_id"},
+			Properties: map[string]property{
+				"note_id": {Type: "string", Description: "Note ID."},
+			},
+		},
+	}
+
+	toolSaveNote = toolDef{
+		Name:        "save_note",
+		Description: "Create or update a note. Omit note_id to create. On update, version must match the current stored version.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"title", "content"},
+			Properties: map[string]property{
+				"note_id": {Type: "string", Description: "Note ID (omit to create)."},
+				"title":   {Type: "string", Description: "Note title."},
+				"content": {Type: "string", Description: "Note body (max 1MB)."},
+				"tags":    {Type: "array", Description: "Tag list.", Items: &items{Type: "string"}},
+				"version": {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
+			},
+		},
+	}
+
+	toolDeleteNote = toolDef{
+		Name:        "delete_note",
+		Description: "Delete a note and its content.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"note_id"},
+			Properties: map[string]property{
+				"note_id": {Type: "string", Description: "Note ID."},
+			},
+		},
+	}
+
+	toolListTodoLists = toolDef{
+		Name:        "list_todo_lists",
+		Description: "List all todo lists.",
+		InputSchema: schema{Type: "object"},
+	}
+
+	toolSaveTodoList = toolDef{
+		Name:        "save_todo_list",
+		Description: "Create or update a todo list. Omit list_id to create.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"title"},
+			Properties: map[string]property{
+				"list_id": {Type: "string", Description: "List ID (omit to create)."},
+				"title":   {Type: "string", Description: "List title."},
+				"tags":    {Type: "array", Description: "Tag list.", Items: &items{Type: "string"}},
+				"version": {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
+			},
+		},
+	}
+
+	toolDeleteTodoList = toolDef{
+		Name:        "delete_todo_list",
+		Description: "Delete a todo list. Does not cascade-delete its todos.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"list_id"},
+			Properties: map[string]property{
+				"list_id": {Type: "string", Description: "List ID."},
+			},
+		},
+	}
+
+	toolListTodos = toolDef{
+		Name:        "list_todos",
+		Description: "List todos in a list, optionally filtered by status or modified-since.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"list_id"},
+			Properties: map[string]property{
+				"list_id":        {Type: "string", Description: "List ID."},
+				"status":         {Type: "string", Description: "Filter by status.", Enum: []string{"pending", "in_progress", "done"}},
+				"modified_since": {Type: "string", Description: "ISO 8601 timestamp; only return todos modified after this time."},
+			},
+		},
+	}
+
+	toolSaveTodo = toolDef{
+		Name:        "save_todo",
+		Description: "Create or update a todo item. Omit todo_id to create.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"list_id", "text"},
+			Properties: map[string]property{
+				"list_id":  {Type: "string", Description: "List ID."},
+				"todo_id":  {Type: "string", Description: "Todo ID (omit to create)."},
+				"text":     {Type: "string", Description: "Todo item text."},
+				"status":   {Type: "string", Description: "Todo status.", Enum: []string{"pending", "in_progress", "done"}},
+				"due_date": {Type: "string", Description: "Due date (RFC3339)."},
+				"tags":     {Type: "array", Description: "Tag list.", Items: &items{Type: "string"}},
+				"version":  {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
+			},
+		},
+	}
+
+	toolDeleteTodo = toolDef{
+		Name:        "delete_todo",
+		Description: "Delete a todo item.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"list_id", "todo_id"},
+			Properties: map[string]property{
+				"list_id": {Type: "string", Description: "List ID."},
+				"todo_id": {Type: "string", Description: "Todo ID."},
+			},
+		},
+	}
+
+	toolListFiles = toolDef{
+		Name:        "list_files",
+		Description: "List file metadata, optionally filtered by modified-since timestamp.",
+		InputSchema: schema{
+			Type: "object",
+			Properties: map[string]property{
+				"modified_since": {Type: "string", Description: "ISO 8601 timestamp; only return files modified after this time."},
+			},
+		},
+	}
+
+	toolGetFile = toolDef{
+		Name:        "get_file",
+		Description: "Get file metadata and full content by path.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"path"},
+			Properties: map[string]property{
+				"path": {Type: "string", Description: "File path."},
+			},
+		},
+	}
+
+	toolSaveFile = toolDef{
+		Name:        "save_file",
+		Description: "Create or update a file. On update, version must match the current stored version.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"path", "content"},
+			Properties: map[string]property{
+				"path":    {Type: "string", Description: "File path."},
+				"content": {Type: "string", Description: "File content (max 1MB)."},
+				"version": {Type: "number", Description: "Current version for optimistic concurrency (omit when creating)."},
+			},
+		},
+	}
+
+	toolDeleteFile = toolDef{
+		Name:        "delete_file",
+		Description: "Delete a file and its content.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"path"},
+			Properties: map[string]property{
+				"path": {Type: "string", Description: "File path."},
+			},
+		},
+	}
+
+	toolListUsers = toolDef{
+		Name:        "list_users",
+		Description: "List users, optionally filtered by status.",
+		InputSchema: schema{
+			Type: "object",
+			Properties: map[string]property{
+				"status": {Type: "string", Description: "Filter by status.", Enum: []string{"pending", "user", "admin", "banned"}},
+			},
+		},
+	}
+
+	toolUpdateUser = toolDef{
+		Name:        "update_user",
+		Description: "Update a user's status.",
+		InputSchema: schema{
+			Type:     "object",
+			Required: []string{"user_id", "status"},
+			Properties: map[string]property{
+				"user_id": {Type: "string", Description: "User ID."},
+				"status":  {Type: "string", Description: "New status.", Enum: []string{"pending", "user", "admin", "banned"}},
+			},
+		},
+	}
+)
+
+// userTools are the 13 tools available to all active users.
+var userTools = []toolDef{
+	toolSearchNotes,
+	toolGetNote,
+	toolSaveNote,
+	toolDeleteNote,
+	toolListTodoLists,
+	toolSaveTodoList,
+	toolDeleteTodoList,
+	toolListTodos,
+	toolSaveTodo,
+	toolDeleteTodo,
+	toolListFiles,
+	toolGetFile,
+	toolSaveFile,
+	toolDeleteFile,
+}
+
+// adminOnlyTools are the 2 additional tools available to admins.
+var adminOnlyTools = []toolDef{
+	toolListUsers,
+	toolUpdateUser,
+}
+
+// toolsForUser returns the tool list appropriate for the given user's role.
+func toolsForUser(user *models.User) []toolDef {
+	switch user.Status {
+	case models.StatusUser:
+		return userTools
+	case models.StatusAdmin:
+		tools := make([]toolDef, len(userTools)+len(adminOnlyTools))
+		copy(tools, userTools)
+		copy(tools[len(userTools):], adminOnlyTools)
+		return tools
+	default:
+		// pending or banned — check_status only
+		return []toolDef{toolCheckStatus}
+	}
+}
+
+// callTool dispatches to the appropriate tool handler.
+func (h *Handler) callTool(ctx context.Context, user *models.User, name string, args map[string]any) (*toolsCallResult, *rpcError) {
+	switch name {
+	case "check_status":
+		return handleCheckStatus(user)
+	case "search_notes":
+		return h.handleSearchNotes(ctx, user, args)
+	case "get_note":
+		return h.handleGetNote(ctx, user, args)
+	case "save_note":
+		return h.handleSaveNote(ctx, user, args)
+	case "delete_note":
+		return h.handleDeleteNote(ctx, user, args)
+	case "list_todo_lists":
+		return h.handleListTodoLists(ctx, user, args)
+	case "save_todo_list":
+		return h.handleSaveTodoList(ctx, user, args)
+	case "delete_todo_list":
+		return h.handleDeleteTodoList(ctx, user, args)
+	case "list_todos":
+		return h.handleListTodos(ctx, user, args)
+	case "save_todo":
+		return h.handleSaveTodo(ctx, user, args)
+	case "delete_todo":
+		return h.handleDeleteTodo(ctx, user, args)
+	case "list_files":
+		return h.handleListFiles(ctx, user, args)
+	case "get_file":
+		return h.handleGetFile(ctx, user, args)
+	case "save_file":
+		return h.handleSaveFile(ctx, user, args)
+	case "delete_file":
+		return h.handleDeleteFile(ctx, user, args)
+	case "list_users":
+		return h.handleListUsers(ctx, args)
+	case "update_user":
+		return h.handleUpdateUser(ctx, args)
+	default:
+		return nil, &rpcError{Code: codeMethodNotFound, Message: fmt.Sprintf("unknown tool: %s", name)}
+	}
+}

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -13,6 +13,11 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 	var statusFilter *models.UserStatus
 	if statusStr != "" {
 		s := models.UserStatus(statusStr)
+		switch s {
+		case models.StatusPending, models.StatusUser, models.StatusAdmin, models.StatusBanned:
+		default:
+			return nil, &rpcError{Code: codeInvalidParams, Message: "invalid status value"}
+		}
 		statusFilter = &s
 	}
 	users, err := h.db.ListUsers(ctx, statusFilter)

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -28,7 +28,7 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 	return jsonResult(users)
 }
 
-func (h *Handler) handleUpdateUser(ctx context.Context, args map[string]any) (*toolsCallResult, *rpcError) {
+func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
 	userID, err := strArg(args, "user_id")
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
@@ -45,6 +45,10 @@ func (h *Handler) handleUpdateUser(ctx context.Context, args map[string]any) (*t
 		return nil, &rpcError{Code: codeInvalidParams, Message: "invalid status value"}
 	}
 
+	if userID == caller.UserID && status != models.StatusAdmin {
+		return errorResult("admins cannot change their own status")
+	}
+
 	if err := h.db.UpdateUserStatus(ctx, userID, status); err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return errorResult("user not found")
@@ -54,4 +58,3 @@ func (h *Handler) handleUpdateUser(ctx context.Context, args map[string]any) (*t
 	log.Printf("admin: user %s status set to %s", userID, status)
 	return textResult("user updated")
 }
-

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/pwntato/notoriousmcp/internal/db"
+	"github.com/pwntato/notoriousmcp/internal/models"
+)
+
+func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*toolsCallResult, *rpcError) {
+	statusStr := strArgOpt(args, "status")
+	var statusFilter *models.UserStatus
+	if statusStr != "" {
+		s := models.UserStatus(statusStr)
+		statusFilter = &s
+	}
+	users, err := h.db.ListUsers(ctx, statusFilter)
+	if err != nil {
+		return dbErrResult(err)
+	}
+	return jsonResult(users)
+}
+
+func (h *Handler) handleUpdateUser(ctx context.Context, args map[string]any) (*toolsCallResult, *rpcError) {
+	userID, err := strArg(args, "user_id")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	statusStr, err := strArg(args, "status")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+
+	status := models.UserStatus(statusStr)
+	switch status {
+	case models.StatusPending, models.StatusUser, models.StatusAdmin, models.StatusBanned:
+	default:
+		return nil, &rpcError{Code: codeInvalidParams, Message: "invalid status value"}
+	}
+
+	if err := h.db.UpdateUserStatus(ctx, userID, status); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return errorResult("user not found")
+		}
+		return dbErrResult(err)
+	}
+	return textResult("user updated")
+}
+
+// isNotFound returns true when err is db.ErrNotFound.
+func isNotFound(err error) bool {
+	return errors.Is(err, db.ErrNotFound)
+}

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -48,7 +48,3 @@ func (h *Handler) handleUpdateUser(ctx context.Context, args map[string]any) (*t
 	return textResult("user updated")
 }
 
-// isNotFound returns true when err is db.ErrNotFound.
-func isNotFound(err error) bool {
-	return errors.Is(err, db.ErrNotFound)
-}

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log"
 
 	"github.com/pwntato/notoriousmcp/internal/db"
 	"github.com/pwntato/notoriousmcp/internal/models"
@@ -50,6 +51,7 @@ func (h *Handler) handleUpdateUser(ctx context.Context, args map[string]any) (*t
 		}
 		return dbErrResult(err)
 	}
+	log.Printf("admin: user %s status set to %s", userID, status)
 	return textResult("user updated")
 }
 

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -14,7 +14,10 @@ import (
 )
 
 func (h *Handler) handleListFiles(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
-	modifiedSince := strArgOpt(args, "modified_since")
+	modifiedSince, rpcErr := parseModifiedSince(strArgOpt(args, "modified_since"))
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
 	files, err := h.db.ListFiles(ctx, user.UserID, modifiedSince)
 	if err != nil {
 		return dbErrResult(err)
@@ -76,7 +79,6 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 	}
 
 	now := time.Now().UTC()
-	s3Key := fmt.Sprintf("files/%s/%s", user.UserID, filePath)
 	var f *models.File
 
 	existing, dbErr := h.db.GetFile(ctx, user.UserID, filePath)
@@ -88,7 +90,7 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		f = &models.File{
 			Path:       filePath,
 			UserID:     user.UserID,
-			S3Key:      s3Key,
+			S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
 			Size:       int64(len(content)),
 			Version:    1,
 			CreatedAt:  now,
@@ -104,7 +106,8 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		f = &models.File{
 			Path:       filePath,
 			UserID:     user.UserID,
-			S3Key:      existing.S3Key,
+			// Fresh S3 key per write: same rationale as handleSaveNote.
+			S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
 			Size:       int64(len(content)),
 			Version:    version,
 			CreatedAt:  existing.CreatedAt,
@@ -112,8 +115,8 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		}
 	}
 
-	// S3 write precedes DynamoDB write; if the DB write fails (e.g. version
-	// conflict) the S3 object becomes orphaned. Same trade-off as handleSaveNote.
+	// S3 write precedes DynamoDB write; on DB conflict the new S3 object is
+	// orphaned but the previous version's object is untouched.
 	if err := h.store.PutContent(ctx, f.S3Key, content); err != nil {
 		if errors.Is(err, store.ErrTooLarge) {
 			return errorResult("content exceeds 1MB limit")

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -88,12 +88,12 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 
 	if existing == nil {
 		f = &models.File{
-			Path:       filePath,
-			UserID:     user.UserID,
+			Path:   filePath,
+			UserID: user.UserID,
 			// Same stable-key-on-create trade-off as handleSaveNote; DB enforces
 			// attribute_not_exists on Version==1 writes.
 			S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
-			Size:       int64(len(content)),
+			Size:       int64(len([]byte(content))),
 			Version:    1,
 			CreatedAt:  now,
 			ModifiedAt: now,
@@ -106,11 +106,11 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 			version = existing.Version + 1
 		}
 		f = &models.File{
-			Path:       filePath,
-			UserID:     user.UserID,
+			Path:   filePath,
+			UserID: user.UserID,
 			// Fresh S3 key per write: same rationale as handleSaveNote.
 			S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
-			Size:       int64(len(content)),
+			Size:       int64(len([]byte(content))),
 			Version:    version,
 			CreatedAt:  existing.CreatedAt,
 			ModifiedAt: now,

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
+	"strings"
 	"time"
 
+	"github.com/pwntato/notoriousmcp/internal/db"
 	"github.com/pwntato/notoriousmcp/internal/models"
 	"github.com/pwntato/notoriousmcp/internal/store"
 )
@@ -20,12 +23,12 @@ func (h *Handler) handleListFiles(ctx context.Context, user *models.User, args m
 }
 
 func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
-	path, err := strArg(args, "path")
+	filePath, err := strArg(args, "path")
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
 
-	f, err := h.db.GetFile(ctx, user.UserID, path)
+	f, err := h.db.GetFile(ctx, user.UserID, filePath)
 	if err != nil {
 		return dbErrResult(err)
 	}
@@ -42,27 +45,36 @@ func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map
 }
 
 func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
-	path, err := strArg(args, "path")
+	rawPath, err := strArg(args, "path")
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
+	// Normalise the path to remove traversal sequences (e.g. "../../foo").
+	// DynamoDB enforces data isolation via PK=USER#<id>, so a crafted path
+	// cannot read another user's data, but cleaning prevents unexpected S3 keys.
+	filePath := path.Clean("/" + strings.ReplaceAll(rawPath, `\`, "/"))
+	filePath = strings.TrimPrefix(filePath, "/")
+	if filePath == "" || filePath == "." {
+		return nil, &rpcError{Code: codeInvalidParams, Message: "invalid path"}
+	}
+
 	content, err := strArg(args, "content")
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
 
 	now := time.Now().UTC()
-	s3Key := fmt.Sprintf("files/%s/%s", user.UserID, path)
+	s3Key := fmt.Sprintf("files/%s/%s", user.UserID, filePath)
 	var f *models.File
 
-	existing, dbErr := h.db.GetFile(ctx, user.UserID, path)
-	if dbErr != nil && !isNotFound(dbErr) {
+	existing, dbErr := h.db.GetFile(ctx, user.UserID, filePath)
+	if dbErr != nil && !errors.Is(dbErr, db.ErrNotFound) {
 		return dbErrResult(dbErr)
 	}
 
 	if existing == nil {
 		f = &models.File{
-			Path:       path,
+			Path:       filePath,
 			UserID:     user.UserID,
 			S3Key:      s3Key,
 			Size:       int64(len(content)),
@@ -76,7 +88,7 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 			version = existing.Version + 1
 		}
 		f = &models.File{
-			Path:       path,
+			Path:       filePath,
 			UserID:     user.UserID,
 			S3Key:      existing.S3Key,
 			Size:       int64(len(content)),
@@ -86,6 +98,8 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		}
 	}
 
+	// S3 write precedes DynamoDB write; if the DB write fails (e.g. version
+	// conflict) the S3 object becomes orphaned. Same trade-off as handleSaveNote.
 	if err := h.store.PutContent(ctx, f.S3Key, content); err != nil {
 		if errors.Is(err, store.ErrTooLarge) {
 			return errorResult("content exceeds 1MB limit")
@@ -101,12 +115,12 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 }
 
 func (h *Handler) handleDeleteFile(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
-	path, err := strArg(args, "path")
+	filePath, err := strArg(args, "path")
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
 
-	f, err := h.db.GetFile(ctx, user.UserID, path)
+	f, err := h.db.GetFile(ctx, user.UserID, filePath)
 	if err != nil {
 		return dbErrResult(err)
 	}
@@ -115,7 +129,7 @@ func (h *Handler) handleDeleteFile(ctx context.Context, user *models.User, args 
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 
-	if err := h.db.DeleteFile(ctx, user.UserID, path); err != nil {
+	if err := h.db.DeleteFile(ctx, user.UserID, filePath); err != nil {
 		return dbErrResult(err)
 	}
 

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -90,7 +90,8 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		f = &models.File{
 			Path:       filePath,
 			UserID:     user.UserID,
-			// Same stable-key-on-create trade-off as handleSaveNote.
+			// Same stable-key-on-create trade-off as handleSaveNote; DB enforces
+			// attribute_not_exists on Version==1 writes.
 			S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
 			Size:       int64(len(content)),
 			Version:    1,

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -22,8 +22,24 @@ func (h *Handler) handleListFiles(ctx context.Context, user *models.User, args m
 	return jsonResult(files)
 }
 
+// cleanFilePath normalises a user-supplied file path: converts backslashes,
+// applies path.Clean to remove traversal sequences, and strips the leading
+// slash. Returns an error for paths that resolve to empty or ".".
+func cleanFilePath(raw string) (string, error) {
+	p := path.Clean("/" + strings.ReplaceAll(raw, `\`, "/"))
+	p = strings.TrimPrefix(p, "/")
+	if p == "" || p == "." {
+		return "", fmt.Errorf("invalid path")
+	}
+	return p, nil
+}
+
 func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
-	filePath, err := strArg(args, "path")
+	raw, err := strArg(args, "path")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	filePath, err := cleanFilePath(raw)
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
@@ -49,13 +65,9 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
-	// Normalise the path to remove traversal sequences (e.g. "../../foo").
-	// DynamoDB enforces data isolation via PK=USER#<id>, so a crafted path
-	// cannot read another user's data, but cleaning prevents unexpected S3 keys.
-	filePath := path.Clean("/" + strings.ReplaceAll(rawPath, `\`, "/"))
-	filePath = strings.TrimPrefix(filePath, "/")
-	if filePath == "" || filePath == "." {
-		return nil, &rpcError{Code: codeInvalidParams, Message: "invalid path"}
+	filePath, err := cleanFilePath(rawPath)
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
 
 	content, err := strArg(args, "content")
@@ -117,7 +129,11 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 }
 
 func (h *Handler) handleDeleteFile(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
-	filePath, err := strArg(args, "path")
+	raw, err := strArg(args, "path")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	filePath, err := cleanFilePath(raw)
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -85,6 +85,8 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 	} else {
 		version := versionArg(args)
 		if version == 0 {
+			// version omitted: auto-increment bypasses optimistic concurrency.
+			// Callers that need conflict detection must pass the current version.
 			version = existing.Version + 1
 		}
 		f = &models.File{
@@ -125,12 +127,13 @@ func (h *Handler) handleDeleteFile(ctx context.Context, user *models.User, args 
 		return dbErrResult(err)
 	}
 
-	if err := h.store.DeleteContent(ctx, f.S3Key); err != nil {
-		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
-	}
-
+	// DB-first: same rationale as handleDeleteNote.
 	if err := h.db.DeleteFile(ctx, user.UserID, filePath); err != nil {
 		return dbErrResult(err)
+	}
+
+	if err := h.store.DeleteContent(ctx, f.S3Key); err != nil {
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 
 	return textResult("file deleted")

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -90,6 +90,7 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		f = &models.File{
 			Path:       filePath,
 			UserID:     user.UserID,
+			// Same stable-key-on-create trade-off as handleSaveNote.
 			S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
 			Size:       int64(len(content)),
 			Version:    1,

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -154,6 +154,8 @@ func (h *Handler) handleDeleteFile(ctx context.Context, user *models.User, args 
 		return dbErrResult(err)
 	}
 
+	// Same rationale as handleDeleteNote: surface the S3 error; a retry hits
+	// ErrNotFound on the DB read and returns gracefully.
 	if err := h.store.DeleteContent(ctx, f.S3Key); err != nil {
 		log.Printf("mcp: delete file %s: s3 delete %s: %v", filePath, f.S3Key, err)
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"path"
 	"strings"
 	"time"
@@ -154,6 +155,7 @@ func (h *Handler) handleDeleteFile(ctx context.Context, user *models.User, args 
 	}
 
 	if err := h.store.DeleteContent(ctx, f.S3Key); err != nil {
+		log.Printf("mcp: delete file %s: s3 delete %s: %v", filePath, f.S3Key, err)
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/pwntato/notoriousmcp/internal/models"
+	"github.com/pwntato/notoriousmcp/internal/store"
+)
+
+func (h *Handler) handleListFiles(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	modifiedSince := strArgOpt(args, "modified_since")
+	files, err := h.db.ListFiles(ctx, user.UserID, modifiedSince)
+	if err != nil {
+		return dbErrResult(err)
+	}
+	return jsonResult(files)
+}
+
+func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	path, err := strArg(args, "path")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+
+	f, err := h.db.GetFile(ctx, user.UserID, path)
+	if err != nil {
+		return dbErrResult(err)
+	}
+
+	content, err := h.store.GetContent(ctx, f.S3Key)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return errorResult("file content not found")
+		}
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+	f.Content = content
+	return jsonResult(f)
+}
+
+func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	path, err := strArg(args, "path")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	content, err := strArg(args, "content")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+
+	now := time.Now().UTC()
+	s3Key := fmt.Sprintf("files/%s/%s", user.UserID, path)
+	var f *models.File
+
+	existing, dbErr := h.db.GetFile(ctx, user.UserID, path)
+	if dbErr != nil && !isNotFound(dbErr) {
+		return dbErrResult(dbErr)
+	}
+
+	if existing == nil {
+		f = &models.File{
+			Path:       path,
+			UserID:     user.UserID,
+			S3Key:      s3Key,
+			Size:       int64(len(content)),
+			Version:    1,
+			CreatedAt:  now,
+			ModifiedAt: now,
+		}
+	} else {
+		version := versionArg(args)
+		if version == 0 {
+			version = existing.Version + 1
+		}
+		f = &models.File{
+			Path:       path,
+			UserID:     user.UserID,
+			S3Key:      existing.S3Key,
+			Size:       int64(len(content)),
+			Version:    version,
+			CreatedAt:  existing.CreatedAt,
+			ModifiedAt: now,
+		}
+	}
+
+	if err := h.store.PutContent(ctx, f.S3Key, content); err != nil {
+		if errors.Is(err, store.ErrTooLarge) {
+			return errorResult("content exceeds 1MB limit")
+		}
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+
+	if err := h.db.SaveFile(ctx, f); err != nil {
+		return dbErrResult(err)
+	}
+
+	return jsonResult(f)
+}
+
+func (h *Handler) handleDeleteFile(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	path, err := strArg(args, "path")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+
+	f, err := h.db.GetFile(ctx, user.UserID, path)
+	if err != nil {
+		return dbErrResult(err)
+	}
+
+	if err := h.store.DeleteContent(ctx, f.S3Key); err != nil {
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+
+	if err := h.db.DeleteFile(ctx, user.UserID, path); err != nil {
+		return dbErrResult(err)
+	}
+
+	return textResult("file deleted")
+}

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -62,15 +62,15 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 	if noteID == "" {
 		noteID = newID()
 		note = &models.Note{
-			ID:         noteID,
-			UserID:     user.UserID,
-			Title:      title,
-			Tags:       tags,
-				// Create path uses a stable key; updates use a fresh key per write.
+			ID:     noteID,
+			UserID: user.UserID,
+			Title:  title,
+			Tags:   tags,
+			// Create path uses a stable key; updates use a fresh key per write.
 			// A failure between the S3 write and the first DB update (v1→v2)
 			// would overwrite this object, but that window is small and the
 			// orphan-on-conflict strategy applies from the second write onward.
-			// The DB enforces attribute_not_exists on Version==1 writes, so two
+			// The DB enforces attribute_not_exists on Version==1 writes, so
 			// concurrent creates for the same ID safely conflict at the DB layer.
 			S3Key:      fmt.Sprintf("notes/%s/%s", user.UserID, noteID),
 			Version:    1,
@@ -89,10 +89,10 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 			version = existing.Version + 1
 		}
 		note = &models.Note{
-			ID:         noteID,
-			UserID:     user.UserID,
-			Title:      title,
-			Tags:       tags,
+			ID:     noteID,
+			UserID: user.UserID,
+			Title:  title,
+			Tags:   tags,
 			// Fresh S3 key per write: if the DB write fails (version conflict),
 			// the new S3 object is orphaned but the DB record still points to the
 			// previous key, so prior content is never overwritten.
@@ -145,4 +145,3 @@ func (h *Handler) handleDeleteNote(ctx context.Context, user *models.User, args 
 
 	return textResult("note deleted")
 }
-

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -89,6 +89,9 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 		}
 	}
 
+	// S3 write precedes DynamoDB write; if the DB write fails (e.g. version
+	// conflict) the S3 object becomes orphaned. Acceptable at current scale —
+	// tracked for future cleanup via a lifecycle policy or explicit rollback.
 	if err := h.store.PutContent(ctx, note.S3Key, content); err != nil {
 		if errors.Is(err, store.ErrTooLarge) {
 			return errorResult("content exceeds 1MB limit")
@@ -125,17 +128,3 @@ func (h *Handler) handleDeleteNote(ctx context.Context, user *models.User, args 
 	return textResult("note deleted")
 }
 
-// versionArg reads the optional "version" argument as int.
-func versionArg(args map[string]any) int {
-	v, ok := args["version"]
-	if !ok {
-		return 0
-	}
-	switch n := v.(type) {
-	case float64:
-		return int(n)
-	case int:
-		return n
-	}
-	return 0
-}

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/pwntato/notoriousmcp/internal/models"
+	"github.com/pwntato/notoriousmcp/internal/store"
+)
+
+func (h *Handler) handleSearchNotes(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	modifiedSince := strArgOpt(args, "modified_since")
+	notes, err := h.db.ListNotes(ctx, user.UserID, modifiedSince)
+	if err != nil {
+		return dbErrResult(err)
+	}
+	return jsonResult(notes)
+}
+
+func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	noteID, err := strArg(args, "note_id")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+
+	note, err := h.db.GetNote(ctx, user.UserID, noteID)
+	if err != nil {
+		return dbErrResult(err)
+	}
+
+	content, err := h.store.GetContent(ctx, note.S3Key)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return errorResult("note content not found")
+		}
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+	note.Content = content
+	return jsonResult(note)
+}
+
+func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	title, err := strArg(args, "title")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	content, err := strArg(args, "content")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	tags := strSliceArgOpt(args, "tags")
+	noteID := strArgOpt(args, "note_id")
+
+	now := time.Now().UTC()
+	var note *models.Note
+
+	if noteID == "" {
+		noteID = newID()
+		note = &models.Note{
+			ID:         noteID,
+			UserID:     user.UserID,
+			Title:      title,
+			Tags:       tags,
+			S3Key:      fmt.Sprintf("notes/%s/%s", user.UserID, noteID),
+			Version:    1,
+			CreatedAt:  now,
+			ModifiedAt: now,
+		}
+	} else {
+		existing, err := h.db.GetNote(ctx, user.UserID, noteID)
+		if err != nil {
+			return dbErrResult(err)
+		}
+		version := versionArg(args)
+		if version == 0 {
+			version = existing.Version + 1
+		}
+		note = &models.Note{
+			ID:         noteID,
+			UserID:     user.UserID,
+			Title:      title,
+			Tags:       tags,
+			S3Key:      existing.S3Key,
+			Version:    version,
+			CreatedAt:  existing.CreatedAt,
+			ModifiedAt: now,
+		}
+	}
+
+	if err := h.store.PutContent(ctx, note.S3Key, content); err != nil {
+		if errors.Is(err, store.ErrTooLarge) {
+			return errorResult("content exceeds 1MB limit")
+		}
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+
+	if err := h.db.SaveNote(ctx, note); err != nil {
+		return dbErrResult(err)
+	}
+
+	return jsonResult(note)
+}
+
+func (h *Handler) handleDeleteNote(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	noteID, err := strArg(args, "note_id")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+
+	note, err := h.db.GetNote(ctx, user.UserID, noteID)
+	if err != nil {
+		return dbErrResult(err)
+	}
+
+	if err := h.store.DeleteContent(ctx, note.S3Key); err != nil {
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+
+	if err := h.db.DeleteNote(ctx, user.UserID, noteID); err != nil {
+		return dbErrResult(err)
+	}
+
+	return textResult("note deleted")
+}
+
+// versionArg reads the optional "version" argument as int.
+func versionArg(args map[string]any) int {
+	v, ok := args["version"]
+	if !ok {
+		return 0
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	}
+	return 0
+}

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -66,7 +66,11 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 			UserID:     user.UserID,
 			Title:      title,
 			Tags:       tags,
-			S3Key:      fmt.Sprintf("notes/%s/%s", user.UserID, noteID),
+			// Create path uses a stable key; updates use a fresh key per write.
+		// A failure between the S3 write and the first DB update (v1→v2)
+		// would overwrite this object, but that window is small and the
+		// orphan-on-conflict strategy applies from the second write onward.
+		S3Key:      fmt.Sprintf("notes/%s/%s", user.UserID, noteID),
 			Version:    1,
 			CreatedAt:  now,
 			ModifiedAt: now,

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -66,11 +66,13 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 			UserID:     user.UserID,
 			Title:      title,
 			Tags:       tags,
-			// Create path uses a stable key; updates use a fresh key per write.
-		// A failure between the S3 write and the first DB update (v1→v2)
-		// would overwrite this object, but that window is small and the
-		// orphan-on-conflict strategy applies from the second write onward.
-		S3Key:      fmt.Sprintf("notes/%s/%s", user.UserID, noteID),
+				// Create path uses a stable key; updates use a fresh key per write.
+			// A failure between the S3 write and the first DB update (v1→v2)
+			// would overwrite this object, but that window is small and the
+			// orphan-on-conflict strategy applies from the second write onward.
+			// The DB enforces attribute_not_exists on Version==1 writes, so two
+			// concurrent creates for the same ID safely conflict at the DB layer.
+			S3Key:      fmt.Sprintf("notes/%s/%s", user.UserID, noteID),
 			Version:    1,
 			CreatedAt:  now,
 			ModifiedAt: now,

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -11,7 +11,10 @@ import (
 )
 
 func (h *Handler) handleSearchNotes(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
-	modifiedSince := strArgOpt(args, "modified_since")
+	modifiedSince, rpcErr := parseModifiedSince(strArgOpt(args, "modified_since"))
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
 	notes, err := h.db.ListNotes(ctx, user.UserID, modifiedSince)
 	if err != nil {
 		return dbErrResult(err)
@@ -84,16 +87,19 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 			UserID:     user.UserID,
 			Title:      title,
 			Tags:       tags,
-			S3Key:      existing.S3Key,
+			// Fresh S3 key per write: if the DB write fails (version conflict),
+			// the new S3 object is orphaned but the DB record still points to the
+			// previous key, so prior content is never overwritten.
+			S3Key:      fmt.Sprintf("notes/%s/%s/%s", user.UserID, noteID, newID()),
 			Version:    version,
 			CreatedAt:  existing.CreatedAt,
 			ModifiedAt: now,
 		}
 	}
 
-	// S3 write precedes DynamoDB write; if the DB write fails (e.g. version
-	// conflict) the S3 object becomes orphaned. Acceptable at current scale —
-	// tracked for future cleanup via a lifecycle policy or explicit rollback.
+	// S3 write precedes DynamoDB write; on DB conflict the new S3 object is
+	// orphaned but the previous version's object is untouched (version-stamped
+	// keys ensure writes never overwrite earlier content).
 	if err := h.store.PutContent(ctx, note.S3Key, content); err != nil {
 		if errors.Is(err, store.ErrTooLarge) {
 			return errorResult("content exceeds 1MB limit")

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -140,6 +140,9 @@ func (h *Handler) handleDeleteNote(ctx context.Context, user *models.User, args 
 		return dbErrResult(err)
 	}
 
+	// Returning an error here even though the DB record is gone is intentional:
+	// the S3 failure is real and the client should know. A retry will hit
+	// ErrNotFound on the DB read and return "not found" gracefully.
 	if err := h.store.DeleteContent(ctx, note.S3Key); err != nil {
 		log.Printf("mcp: delete note %s: s3 delete %s: %v", noteID, note.S3Key, err)
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -75,6 +75,8 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 		}
 		version := versionArg(args)
 		if version == 0 {
+			// version omitted: auto-increment bypasses optimistic concurrency.
+			// Callers that need conflict detection must pass the current version.
 			version = existing.Version + 1
 		}
 		note = &models.Note{
@@ -117,12 +119,16 @@ func (h *Handler) handleDeleteNote(ctx context.Context, user *models.User, args 
 		return dbErrResult(err)
 	}
 
-	if err := h.store.DeleteContent(ctx, note.S3Key); err != nil {
-		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
-	}
-
+	// DB-first: if the S3 delete later fails, the DB record is already gone so
+	// subsequent reads return not-found rather than a dangling pointer. The
+	// orphaned S3 object is recoverable; a dangling DB reference is harder to
+	// detect and correct.
 	if err := h.db.DeleteNote(ctx, user.UserID, noteID); err != nil {
 		return dbErrResult(err)
+	}
+
+	if err := h.store.DeleteContent(ctx, note.S3Key); err != nil {
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 
 	return textResult("note deleted")

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/pwntato/notoriousmcp/internal/models"
@@ -140,6 +141,7 @@ func (h *Handler) handleDeleteNote(ctx context.Context, user *models.User, args 
 	}
 
 	if err := h.store.DeleteContent(ctx, note.S3Key); err != nil {
+		log.Printf("mcp: delete note %s: s3 delete %s: %v", noteID, note.S3Key, err)
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 

--- a/internal/handlers/tools_status.go
+++ b/internal/handlers/tools_status.go
@@ -1,0 +1,14 @@
+package handlers
+
+import "github.com/pwntato/notoriousmcp/internal/models"
+
+func handleCheckStatus(user *models.User) (*toolsCallResult, *rpcError) {
+	switch user.Status {
+	case models.StatusPending:
+		return textResult("Your account is pending admin approval.")
+	case models.StatusBanned:
+		return textResult("Your account has been banned.")
+	default:
+		return textResult("Your account is active.")
+	}
+}

--- a/internal/handlers/tools_status.go
+++ b/internal/handlers/tools_status.go
@@ -6,9 +6,7 @@ func handleCheckStatus(user *models.User) (*toolsCallResult, *rpcError) {
 	switch user.Status {
 	case models.StatusPending:
 		return textResult("Your account is pending admin approval.")
-	case models.StatusBanned:
+	default: // banned
 		return textResult("Your account has been banned.")
-	default:
-		return textResult("Your account is active.")
 	}
 }

--- a/internal/handlers/tools_status.go
+++ b/internal/handlers/tools_status.go
@@ -1,12 +1,19 @@
 package handlers
 
-import "github.com/pwntato/notoriousmcp/internal/models"
+import (
+	"log"
+
+	"github.com/pwntato/notoriousmcp/internal/models"
+)
 
 func handleCheckStatus(user *models.User) (*toolsCallResult, *rpcError) {
 	switch user.Status {
 	case models.StatusPending:
 		return textResult("Your account is pending admin approval.")
-	default: // banned
+	case models.StatusBanned:
 		return textResult("Your account has been banned.")
+	default:
+		log.Printf("mcp: check_status called for unexpected status %q (user %s)", user.Status, user.UserID)
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 }

--- a/internal/handlers/tools_todos.go
+++ b/internal/handlers/tools_todos.go
@@ -1,0 +1,182 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/pwntato/notoriousmcp/internal/models"
+)
+
+func (h *Handler) handleListTodoLists(ctx context.Context, user *models.User, _ map[string]any) (*toolsCallResult, *rpcError) {
+	lists, err := h.db.ListTodoLists(ctx, user.UserID)
+	if err != nil {
+		return dbErrResult(err)
+	}
+	return jsonResult(lists)
+}
+
+func (h *Handler) handleSaveTodoList(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	title, err := strArg(args, "title")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	tags := strSliceArgOpt(args, "tags")
+	listID := strArgOpt(args, "list_id")
+
+	now := time.Now().UTC()
+	var list *models.TodoList
+
+	if listID == "" {
+		listID = newID()
+		list = &models.TodoList{
+			ID:         listID,
+			UserID:     user.UserID,
+			Title:      title,
+			Tags:       tags,
+			Version:    1,
+			CreatedAt:  now,
+			ModifiedAt: now,
+		}
+	} else {
+		existing, err := h.db.GetTodoList(ctx, user.UserID, listID)
+		if err != nil {
+			return dbErrResult(err)
+		}
+		version := versionArg(args)
+		if version == 0 {
+			version = existing.Version + 1
+		}
+		list = &models.TodoList{
+			ID:         listID,
+			UserID:     user.UserID,
+			Title:      title,
+			Tags:       tags,
+			Version:    version,
+			CreatedAt:  existing.CreatedAt,
+			ModifiedAt: now,
+		}
+	}
+
+	if err := h.db.SaveTodoList(ctx, list); err != nil {
+		return dbErrResult(err)
+	}
+	return jsonResult(list)
+}
+
+func (h *Handler) handleDeleteTodoList(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	listID, err := strArg(args, "list_id")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	if err := h.db.DeleteTodoList(ctx, user.UserID, listID); err != nil {
+		return dbErrResult(err)
+	}
+	return textResult("todo list deleted")
+}
+
+func (h *Handler) handleListTodos(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	listID, err := strArg(args, "list_id")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	modifiedSince := strArgOpt(args, "modified_since")
+	statusStr := strArgOpt(args, "status")
+
+	var statusFilter *models.TodoStatus
+	if statusStr != "" {
+		s := models.TodoStatus(statusStr)
+		statusFilter = &s
+	}
+
+	todos, err := h.db.ListTodos(ctx, user.UserID, listID, modifiedSince, statusFilter)
+	if err != nil {
+		return dbErrResult(err)
+	}
+	return jsonResult(todos)
+}
+
+func (h *Handler) handleSaveTodo(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	listID, err := strArg(args, "list_id")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	text, err := strArg(args, "text")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+
+	todoID := strArgOpt(args, "todo_id")
+	statusStr := strArgOpt(args, "status")
+	tags := strSliceArgOpt(args, "tags")
+	dueDateStr := strArgOpt(args, "due_date")
+
+	dueDate, parseErr := parseOptionalTime(dueDateStr)
+	if parseErr != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: parseErr.Error()}
+	}
+
+	status := models.TodoPending
+	if statusStr != "" {
+		status = models.TodoStatus(statusStr)
+	}
+
+	now := time.Now().UTC()
+	var todo *models.Todo
+
+	if todoID == "" {
+		todoID = newID()
+		todo = &models.Todo{
+			ID:         todoID,
+			ListID:     listID,
+			UserID:     user.UserID,
+			Text:       text,
+			Status:     status,
+			DueDate:    dueDate,
+			Tags:       tags,
+			Version:    1,
+			CreatedAt:  now,
+			ModifiedAt: now,
+		}
+	} else {
+		existing, err := h.db.GetTodo(ctx, user.UserID, listID, todoID)
+		if err != nil {
+			return dbErrResult(err)
+		}
+		version := versionArg(args)
+		if version == 0 {
+			version = existing.Version + 1
+		}
+		todo = &models.Todo{
+			ID:         todoID,
+			ListID:     listID,
+			UserID:     user.UserID,
+			Text:       text,
+			Status:     status,
+			DueDate:    dueDate,
+			Tags:       tags,
+			Version:    version,
+			CreatedAt:  existing.CreatedAt,
+			ModifiedAt: now,
+		}
+	}
+
+	if err := h.db.SaveTodo(ctx, todo); err != nil {
+		return dbErrResult(err)
+	}
+	return jsonResult(todo)
+}
+
+func (h *Handler) handleDeleteTodo(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
+	listID, err := strArg(args, "list_id")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	todoID, err := strArg(args, "todo_id")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	if err := h.db.DeleteTodo(ctx, user.UserID, listID, todoID); err != nil {
+		return dbErrResult(err)
+	}
+	return textResult("todo deleted")
+}

--- a/internal/handlers/tools_todos.go
+++ b/internal/handlers/tools_todos.go
@@ -128,6 +128,11 @@ func (h *Handler) handleSaveTodo(ctx context.Context, user *models.User, args ma
 	status := models.TodoPending
 	if statusStr != "" {
 		status = models.TodoStatus(statusStr)
+		switch status {
+		case models.TodoPending, models.TodoInProgress, models.TodoDone:
+		default:
+			return nil, &rpcError{Code: codeInvalidParams, Message: "invalid status value"}
+		}
 	}
 
 	now := time.Now().UTC()

--- a/internal/handlers/tools_todos.go
+++ b/internal/handlers/tools_todos.go
@@ -81,7 +81,10 @@ func (h *Handler) handleListTodos(ctx context.Context, user *models.User, args m
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
-	modifiedSince := strArgOpt(args, "modified_since")
+	modifiedSince, rpcErr := parseModifiedSince(strArgOpt(args, "modified_since"))
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
 	statusStr := strArgOpt(args, "status")
 
 	var statusFilter *models.TodoStatus

--- a/internal/handlers/tools_todos.go
+++ b/internal/handlers/tools_todos.go
@@ -70,6 +70,8 @@ func (h *Handler) handleDeleteTodoList(ctx context.Context, user *models.User, a
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
+	// DeleteTodoList is scoped by userID at the DB layer (PK = USER#userID),
+	// so no explicit ownership fetch is needed before deleting.
 	if err := h.db.DeleteTodoList(ctx, user.UserID, listID); err != nil {
 		return dbErrResult(err)
 	}

--- a/internal/handlers/tools_todos.go
+++ b/internal/handlers/tools_todos.go
@@ -44,6 +44,8 @@ func (h *Handler) handleSaveTodoList(ctx context.Context, user *models.User, arg
 		}
 		version := versionArg(args)
 		if version == 0 {
+			// version omitted: auto-increment bypasses optimistic concurrency.
+			// Callers that need conflict detection must pass the current version.
 			version = existing.Version + 1
 		}
 		list = &models.TodoList{
@@ -144,6 +146,8 @@ func (h *Handler) handleSaveTodo(ctx context.Context, user *models.User, args ma
 		}
 		version := versionArg(args)
 		if version == 0 {
+			// version omitted: auto-increment bypasses optimistic concurrency.
+			// Callers that need conflict detection must pass the current version.
 			version = existing.Version + 1
 		}
 		todo = &models.Todo{

--- a/internal/handlers/tools_todos.go
+++ b/internal/handlers/tools_todos.go
@@ -143,8 +143,11 @@ func (h *Handler) handleSaveTodo(ctx context.Context, user *models.User, args ma
 	if todoID == "" {
 		todoID = newID()
 		todo = &models.Todo{
-			ID:         todoID,
-			ListID:     listID,
+			ID:     todoID,
+			ListID: listID,
+			// UserID is always the authenticated caller — DynamoDB uses PK=USER#<userID>
+			// so this write can only land under the caller's partition, making
+			// cross-user writes impossible at the DB layer regardless of list_id.
 			UserID:     user.UserID,
 			Text:       text,
 			Status:     status,

--- a/internal/handlers/tools_todos.go
+++ b/internal/handlers/tools_todos.go
@@ -87,6 +87,11 @@ func (h *Handler) handleListTodos(ctx context.Context, user *models.User, args m
 	var statusFilter *models.TodoStatus
 	if statusStr != "" {
 		s := models.TodoStatus(statusStr)
+		switch s {
+		case models.TodoPending, models.TodoInProgress, models.TodoDone:
+		default:
+			return nil, &rpcError{Code: codeInvalidParams, Message: "invalid status value"}
+		}
 		statusFilter = &s
 	}
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -25,7 +25,7 @@ type Note struct {
 	UserID     string    `json:"user_id"     dynamodbav:"UserID"`
 	Title      string    `json:"title"       dynamodbav:"Title"`
 	Tags       []string  `json:"tags"        dynamodbav:"Tags"`
-	S3Key      string    `json:"s3_key"      dynamodbav:"S3Key"`
+	S3Key      string    `json:"-"           dynamodbav:"S3Key"`
 	Version    int       `json:"version"     dynamodbav:"Version"`
 	CreatedAt  time.Time `json:"created_at"  dynamodbav:"CreatedAt"`
 	ModifiedAt time.Time `json:"modified_at" dynamodbav:"ModifiedAt"`
@@ -66,7 +66,7 @@ type Todo struct {
 type File struct {
 	Path       string    `json:"path"        dynamodbav:"Path"`
 	UserID     string    `json:"user_id"     dynamodbav:"UserID"`
-	S3Key      string    `json:"s3_key"      dynamodbav:"S3Key"`
+	S3Key      string    `json:"-"           dynamodbav:"S3Key"`
 	Size       int64     `json:"size"        dynamodbav:"Size"`
 	Version    int       `json:"version"     dynamodbav:"Version"`
 	CreatedAt  time.Time `json:"created_at"  dynamodbav:"CreatedAt"`


### PR DESCRIPTION
## Summary

- Implements `internal/handlers/` with full MCP JSON-RPC 2.0 protocol handler
- `initialize`, `tools/list`, and `tools/call` methods
- Dynamic tool list gated on user role (from context via `auth.UserFromContext`):
  - `pending` / `banned` → `check_status` only
  - `user` → 14 tools (notes × 4, todo-lists × 3, todos × 3, files × 4)
  - `admin` → 16 tools (user tools + `list_users` + `update_user`)
- Tool handlers: notes (with S3 content), todo lists, todos, files, admin ops, check_status
- Exports `auth.WithUserContext` so tests can inject a user without running full middleware
- `cmd/local/main.go` wired up: auth routes public, `/mcp` protected by `auth.Middleware`

## Note on tool count

The issue table says "13 standard tools" but lists 14 tool names (4 notes + 3 todo-lists + 3 todos + 4 files). This implementation uses 14 — the listed names are the source of truth.

## Test plan

- [ ] `go test ./internal/handlers/` — 13 unit tests pass with no DB/S3
- [ ] `DYNAMODB_ENDPOINT=... S3_ENDPOINT=... go test ./internal/handlers/ -run ^TestIntegration` — 5 integration tests pass against local stack
- [ ] `go test ./internal/auth/` — all existing auth tests still pass
- [ ] `go build ./...` — clean build

🤖 Generated with [Claude Code](https://claude.ai/claude-code)