### PR TITLE
feat: wire cmd/server/main.go for Lambda (#11)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,8 @@ jobs:
           TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
           TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           TF_VAR_admin_google_ids: ${{ secrets.ADMIN_GOOGLE_IDS }}
+          TF_VAR_token_secret: ${{ secrets.TOKEN_SECRET }}
+          TF_VAR_redirect_url: ${{ secrets.REDIRECT_URL }}
 
       - name: terraform apply
         run: terraform apply -auto-approve tfplan

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -84,6 +84,7 @@ func init() {
 func lambdaHandler(ctx context.Context, req events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
 	httpReq, err := toHTTPRequest(ctx, req)
 	if err != nil {
+		log.Printf("toHTTPRequest: %v", err)
 		return events.LambdaFunctionURLResponse{
 			StatusCode: 400,
 			Headers:    map[string]string{"Content-Type": "application/json"},
@@ -100,10 +101,19 @@ func lambdaHandler(ctx context.Context, req events.LambdaFunctionURLRequest) (ev
 		headers[k] = strings.Join(vs, ", ")
 	}
 
+	body := rec.Body.String()
+	isBase64 := false
+	ct := resp.Header.Get("Content-Type")
+	if ct != "" && !strings.HasPrefix(ct, "text/") && !strings.HasPrefix(ct, "application/json") && !strings.HasPrefix(ct, "application/problem+json") {
+		body = base64.StdEncoding.EncodeToString(rec.Body.Bytes())
+		isBase64 = true
+	}
+
 	return events.LambdaFunctionURLResponse{
-		StatusCode: resp.StatusCode,
-		Headers:    headers,
-		Body:       rec.Body.String(),
+		StatusCode:      resp.StatusCode,
+		Headers:         headers,
+		Body:            body,
+		IsBase64Encoded: isBase64,
 	}, nil
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,18 +2,148 @@ package main
 
 import (
 	"context"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+
+	"github.com/pwntato/notoriousmcp/internal/auth"
+	"github.com/pwntato/notoriousmcp/internal/db"
+	"github.com/pwntato/notoriousmcp/internal/handlers"
+	"github.com/pwntato/notoriousmcp/internal/store"
 )
 
-func handler(ctx context.Context, req events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
+var handler http.Handler
+
+func init() {
+	ctx := context.Background()
+
+	awsCfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		log.Fatalf("aws config: %v", err)
+	}
+
+	ssmClient := ssm.NewFromConfig(awsCfg)
+	ssmGet := func(name string) string {
+		out, err := ssmClient.GetParameter(ctx, &ssm.GetParameterInput{
+			Name:           aws.String(name),
+			WithDecryption: aws.Bool(true),
+		})
+		if err != nil {
+			log.Fatalf("ssm get %s: %v", name, err)
+		}
+		return aws.ToString(out.Parameter.Value)
+	}
+
+	tableName := mustEnv("TABLE_NAME")
+	dbClient, err := db.New(ctx, tableName, "")
+	if err != nil {
+		log.Fatalf("db: %v", err)
+	}
+
+	bucket := mustEnv("S3_BUCKET")
+	storeClient, err := store.New(ctx, bucket, "")
+	if err != nil {
+		log.Fatalf("store: %v", err)
+	}
+
+	adminIDsRaw := ssmGet(mustEnv("SSM_ADMIN_GOOGLE_IDS"))
+	tokenSecretRaw := ssmGet(mustEnv("SSM_TOKEN_SECRET"))
+	authCfg := auth.Config{
+		ClientID:       ssmGet(mustEnv("SSM_GOOGLE_CLIENT_ID")),
+		ClientSecret:   ssmGet(mustEnv("SSM_GOOGLE_CLIENT_SECRET")),
+		RedirectURL:    mustEnv("REDIRECT_URL"),
+		AdminGoogleIDs: filterEmpty(strings.Split(adminIDsRaw, ",")),
+		TokenSecret:    []byte(tokenSecretRaw),
+		TrustProxy:     true,
+	}
+
+	authHandler := auth.New(authCfg, dbClient)
+	mcpHandler := handlers.New(dbClient, storeClient)
+
+	mux := http.NewServeMux()
+	authHandler.RegisterRoutes(mux)
+	mcpHandler.RegisterRoutes(mux)
+
+	protected := auth.Middleware(authCfg, dbClient, mux)
+	handler = publicRouter(mux, protected)
+}
+
+func lambdaHandler(ctx context.Context, req events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
+	httpReq, err := toHTTPRequest(ctx, req)
+	if err != nil {
+		return events.LambdaFunctionURLResponse{StatusCode: 400}, nil
+	}
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httpReq)
+
+	resp := rec.Result()
+	headers := make(map[string]string, len(resp.Header))
+	for k, vs := range resp.Header {
+		headers[k] = strings.Join(vs, ", ")
+	}
+
 	return events.LambdaFunctionURLResponse{
-		StatusCode: 200,
-		Body:       `{"status":"ok"}`,
+		StatusCode: resp.StatusCode,
+		Headers:    headers,
+		Body:       rec.Body.String(),
 	}, nil
 }
 
 func main() {
-	lambda.Start(handler)
+	lambda.Start(lambdaHandler)
+}
+
+func toHTTPRequest(ctx context.Context, req events.LambdaFunctionURLRequest) (*http.Request, error) {
+	url := "https://" + req.RequestContext.DomainName + req.RawPath
+	if req.RawQueryString != "" {
+		url += "?" + req.RawQueryString
+	}
+
+	body := strings.NewReader(req.Body)
+	httpReq, err := http.NewRequestWithContext(ctx, req.RequestContext.HTTP.Method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range req.Headers {
+		httpReq.Header.Set(k, v)
+	}
+	return httpReq, nil
+}
+
+func publicRouter(public, protected http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/auth/") ||
+			strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			public.ServeHTTP(w, r)
+			return
+		}
+		protected.ServeHTTP(w, r)
+	})
+}
+
+func mustEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		log.Fatalf("required env var %s is not set", key)
+	}
+	return v
+}
+
+func filterEmpty(ss []string) []string {
+	var out []string
+	for _, s := range ss {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -23,7 +27,8 @@ import (
 var handler http.Handler
 
 func init() {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	awsCfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
@@ -79,7 +84,11 @@ func init() {
 func lambdaHandler(ctx context.Context, req events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
 	httpReq, err := toHTTPRequest(ctx, req)
 	if err != nil {
-		return events.LambdaFunctionURLResponse{StatusCode: 400}, nil
+		return events.LambdaFunctionURLResponse{
+			StatusCode: 400,
+			Headers:    map[string]string{"Content-Type": "application/json"},
+			Body:       `{"error":"bad request"}`,
+		}, nil
 	}
 
 	rec := httptest.NewRecorder()
@@ -108,8 +117,18 @@ func toHTTPRequest(ctx context.Context, req events.LambdaFunctionURLRequest) (*h
 		url += "?" + req.RawQueryString
 	}
 
-	body := strings.NewReader(req.Body)
-	httpReq, err := http.NewRequestWithContext(ctx, req.RequestContext.HTTP.Method, url, body)
+	var bodyReader io.Reader
+	if req.IsBase64Encoded {
+		decoded, err := base64.StdEncoding.DecodeString(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(decoded)
+	} else {
+		bodyReader = strings.NewReader(req.Body)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, req.RequestContext.HTTP.Method, url, bodyReader)
 	if err != nil {
 		return nil, err
 	}
@@ -119,6 +138,9 @@ func toHTTPRequest(ctx context.Context, req events.LambdaFunctionURLRequest) (*h
 	return httpReq, nil
 }
 
+// publicRouter bypasses auth middleware for /auth/ and /.well-known/ paths.
+// Both public and protected wrap the same underlying mux; the distinction is
+// that protected passes requests through auth.Middleware first.
 func publicRouter(public, protected http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/auth/") ||

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.39
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6
 	golang.org/x/oauth2 v0.36.0
 )
 
@@ -27,7 +28,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1 h1:mxuT1xE+dI54NW3RkNjP8DUT5HXq
 github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11/go.mod h1:R82ZRExE/nheo0N+T8zHPcLRTcH8MGsnR3BiVGX0TwI=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6 h1:0LPJjbSNEDHidGOXa0LfvSVbdn9/GdlJUQTgE0kFpso=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6/go.mod h1:SrZAopBP5/lyQ6NBVXKlRp8wPIXhzBCZU98sEozmv8Y=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 h1:7byT8HUWrgoRp6sXjxtZwgOKfhss5fW6SkLBtqzgRoE=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.17/go.mod h1:xNWknVi4Ezm1vg1QsB/5EWpAJURq22uqd38U8qKvOJc=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 h1:+1Kl1zx6bWi4X7cKi3VYh29h8BvsCoHQEQ6ST9X8w7w=

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -52,6 +52,7 @@ data "aws_iam_policy_document" "lambda_policy" {
       aws_ssm_parameter.google_client_id.arn,
       aws_ssm_parameter.google_client_secret.arn,
       aws_ssm_parameter.admin_google_ids.arn,
+      aws_ssm_parameter.token_secret.arn,
     ]
   }
 }
@@ -83,9 +84,11 @@ resource "aws_lambda_function" "main" {
       TABLE_NAME               = var.table_name
       S3_BUCKET                = aws_s3_bucket.content.bucket
       ENVIRONMENT              = var.environment
+      REDIRECT_URL             = var.redirect_url
       SSM_GOOGLE_CLIENT_ID     = aws_ssm_parameter.google_client_id.name
       SSM_GOOGLE_CLIENT_SECRET = aws_ssm_parameter.google_client_secret.name
       SSM_ADMIN_GOOGLE_IDS     = aws_ssm_parameter.admin_google_ids.name
+      SSM_TOKEN_SECRET         = aws_ssm_parameter.token_secret.name
     }
   }
 

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -15,3 +15,9 @@ resource "aws_ssm_parameter" "admin_google_ids" {
   type  = "SecureString"
   value = var.admin_google_ids
 }
+
+resource "aws_ssm_parameter" "token_secret" {
+  name  = "/notoriousmcp/${var.environment}/token_secret"
+  type  = "SecureString"
+  value = var.token_secret
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -14,6 +14,8 @@
 #   GOOGLE_CLIENT_ID      — from Google Cloud Console
 #   GOOGLE_CLIENT_SECRET  — from Google Cloud Console
 #   ADMIN_GOOGLE_IDS      — comma-separated Google subject IDs
+#   TOKEN_SECRET          — min 32-byte random string for HMAC signing (e.g. openssl rand -base64 32)
+#   REDIRECT_URL          — full OAuth callback URL (e.g. https://YOUR_CF_DOMAIN/auth/callback)
 #
 # Note: No AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY needed — CI uses OIDC federation.
 
@@ -22,6 +24,8 @@ state_bucket         = "notoriousmcp-tfstate-YOUR_ACCOUNT_ID"
 google_client_id     = "YOUR_GOOGLE_CLIENT_ID"
 google_client_secret = "YOUR_GOOGLE_CLIENT_SECRET"
 admin_google_ids     = "GOOGLE_SUB_ID_1,GOOGLE_SUB_ID_2"
+token_secret         = "YOUR_RANDOM_SECRET_MIN_32_BYTES"
+redirect_url         = "https://YOUR_CLOUDFRONT_DOMAIN/auth/callback"
 
 # Optional — leave domain_name empty to use the CloudFront URL directly
 domain_name = "notoriousmcp.com"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,6 +34,17 @@ variable "admin_google_ids" {
   description = "Comma-separated Google subject IDs for bootstrap admins"
 }
 
+variable "token_secret" {
+  type        = string
+  sensitive   = true
+  description = "HMAC signing secret for access tokens (min 32 bytes)"
+}
+
+variable "redirect_url" {
+  type        = string
+  description = "Full OAuth callback URL registered in Google Cloud Console (e.g. https://example.com/auth/callback)"
+}
+
 variable "domain_name" {
   type        = string
   default     = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,6 +38,10 @@ variable "token_secret" {
   type        = string
   sensitive   = true
   description = "HMAC signing secret for access tokens (min 32 bytes)"
+  validation {
+    condition     = length(var.token_secret) >= 32
+    error_message = "token_secret must be at least 32 bytes."
+  }
 }
 
 variable "redirect_url" {


### PR DESCRIPTION
## Summary

- Replaces the stub `cmd/server/main.go` with a full Lambda Function URL handler
- Loads `google_client_id`, `google_client_secret`, `admin_google_ids`, and `token_secret` from SSM Parameter Store at cold start
- Thin manual adapter converts `LambdaFunctionURLRequest` → `*http.Request` / `httptest.ResponseRecorder` → `LambdaFunctionURLResponse` (no extra deps)
- Wires auth middleware + MCP handler via same `publicRouter` pattern as local server; `TrustProxy: true` behind CloudFront
- Terraform: adds `token_secret` SSM param, `var.token_secret` + `var.redirect_url` variables, IAM permission, and both new Lambda env vars
- CI: passes `TOKEN_SECRET` and `REDIRECT_URL` GitHub secrets to `terraform plan`

## New GitHub Actions secrets required before merging

- `TOKEN_SECRET` — min 32-byte random string (`openssl rand -base64 32`)
- `REDIRECT_URL` — full OAuth callback URL (e.g. `https://YOUR_CF_DOMAIN/auth/callback`)

## Test plan

- [ ] All existing unit + integration tests pass (no changes to internal packages)
- [ ] `GOOS=linux GOARCH=arm64 go build ./cmd/server` succeeds
- [ ] Add `TOKEN_SECRET` and `REDIRECT_URL` to GitHub Actions secrets
- [ ] Merge triggers deploy workflow; Lambda updates and responds to requests through CloudFront

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)