### PR TITLE
feat: skill file (issue #12)

### DIFF
--- a/skill/notoriousmcp.md
+++ b/skill/notoriousmcp.md
@@ -1,6 +1,6 @@
-# NoteoriousMCP Skill
+# NotoriousMCP Skill
 
-NoteoriousMCP is a self-hosted MCP server for notes, todo lists, files, and LLM memory — backed by AWS Lambda + DynamoDB + S3. This skill teaches you when and how to use its tools effectively.
+NotoriousMCP is a self-hosted MCP server for notes, todo lists, files, and LLM memory — backed by AWS Lambda + DynamoDB + S3. This skill teaches you when and how to use its tools effectively.
 
 ## Installation
 
@@ -18,14 +18,23 @@ New accounts start as `pending` and only have access to `check_status`. An admin
 
 ## Session Start
 
-At the start of each session, load any persistent memory you've stored:
+At the start of each session, load any persistent memory you've stored. A recommended layout:
 
 ```
-get_file("memory/MEMORY.md")       # index, then fetch individual files as needed
+memory/MEMORY.md      # index: topic → file path
+memory/user.md
+memory/project_foo.md
+memory/feedback.md
+```
+
+Fetch the index first, then individual files as needed:
+
+```
+get_file("memory/MEMORY.md")
 get_file("memory/<topic>.md")
 ```
 
-If `memory/MEMORY.md` doesn't exist yet, skip silently — the user hasn't set up server-side memory yet.
+If `memory/MEMORY.md` doesn't exist yet, skip silently — the user hasn't set up server-side memory yet. This mirrors the local `~/.claude/` memory system but stores data server-side, available across machines.
 
 ## Session End
 
@@ -50,7 +59,7 @@ delete_note(note_id)
 
 - `search_notes` returns metadata only (no content). Use `get_note` to fetch content.
 - Pass `modified_since` (ISO 8601) to fetch only recently changed notes — useful for sync.
-- On update, pass `version` matching the current stored version for conflict-safe writes. Omitting `version` auto-increments and skips conflict detection.
+- On update, pass `version` matching the current stored version for conflict-safe writes. Omit `version` to auto-increment (skips conflict detection).
 - Content limit: 1MB.
 
 ### Todo Lists (user+)
@@ -103,25 +112,12 @@ update_user(user_id, status)
 check_status()    → account status message
 ```
 
-## Memory Pattern
-
-Use `save_file` / `get_file` to persist Claude Code memory on the server. A simple layout:
-
-```
-memory/MEMORY.md          # index of topics → file paths
-memory/user.md
-memory/project_foo.md
-memory/feedback.md
-```
-
-Load `memory/MEMORY.md` at session start, then fetch individual files as needed. Save changes before ending the session. This mirrors the local `~/.claude/` memory system but stores data server-side, shared across machines.
-
 ## Conflict-Safe Writes
 
 Every saved item has a `version` integer. To update safely:
 
 1. Read the item (note, file, todo, etc.) — the response includes `version`.
 2. Pass that `version` back in your `save_*` call.
-3. If another writer changed it in the meantime, the server returns a version conflict error — re-read and retry.
+3. If another writer changed it in the meantime, the tool result will have `isError: true` with the text `"version conflict: reload and retry"` — re-read the item and retry.
 
 Omitting `version` on an update silently auto-increments and skips conflict detection. This is fine for single-writer sessions; use explicit `version` when multiple clients or sessions may write the same item.

--- a/skill/notoriousmcp.md
+++ b/skill/notoriousmcp.md
@@ -4,11 +4,15 @@ NotoriousMCP is a self-hosted MCP server for notes, todo lists, files, and LLM m
 
 ## Installation
 
-```bash
-cp skill/notoriousmcp.md .claude/skills/notoriousmcp.md
+Add to `.claude/settings.json` (or the global `~/.claude/settings.json`):
+
+```json
+{
+  "skills": ["path/to/notoriousmcp/skill/notoriousmcp.md"]
+}
 ```
 
-Or add to Claude Code settings under `skills`.
+Or copy it to wherever your project's skill files live and reference that path.
 
 ## Auth
 
@@ -67,8 +71,10 @@ delete_note(note_id)
 ```
 list_todo_lists()                                       → []TodoList
 save_todo_list(title, list_id?, tags?, version?)        → TodoList
-delete_todo_list(list_id)                               # does not cascade-delete todos
+delete_todo_list(list_id)
 ```
+
+- `delete_todo_list` does not cascade-delete todos. Orphaned todos remain in DynamoDB and are still reachable via `list_todos(list_id=<deleted_id>)`. Delete the todos first via `delete_todo` if you want a clean removal.
 
 ### Todos (user+)
 
@@ -104,6 +110,7 @@ update_user(user_id, status)
 ```
 
 - `status` enum for users: `pending` | `user` | `admin` | `banned`
+- `user_id` is the Google subject ID (`sub`) — an opaque numeric string returned in the `user_id` field of `list_users` output.
 - Admins cannot change their own status away from `admin`.
 
 ### Status (pending/banned)

--- a/skill/notoriousmcp.md
+++ b/skill/notoriousmcp.md
@@ -1,0 +1,127 @@
+# NoteoriousMCP Skill
+
+NoteoriousMCP is a self-hosted MCP server for notes, todo lists, files, and LLM memory — backed by AWS Lambda + DynamoDB + S3. This skill teaches you when and how to use its tools effectively.
+
+## Installation
+
+```bash
+cp skill/notoriousmcp.md .claude/skills/notoriousmcp.md
+```
+
+Or add to Claude Code settings under `skills`.
+
+## Auth
+
+The server uses Google OAuth 2.0. Access tokens are 1-hour HMAC tokens passed as `Authorization: Bearer <token>`. When a token expires, the server silently issues a fresh one via the `X-New-Token` response header — your MCP client handles this automatically.
+
+New accounts start as `pending` and only have access to `check_status`. An admin must approve you before the full tool set is available.
+
+## Session Start
+
+At the start of each session, load any persistent memory you've stored:
+
+```
+get_file("memory/MEMORY.md")       # index, then fetch individual files as needed
+get_file("memory/<topic>.md")
+```
+
+If `memory/MEMORY.md` doesn't exist yet, skip silently — the user hasn't set up server-side memory yet.
+
+## Session End
+
+Before ending a session where you learned or changed something worth remembering, save updated memory files:
+
+```
+save_file(path="memory/MEMORY.md", content="...", version=<current_version>)
+```
+
+Always pass `version` when updating an existing file to avoid overwriting concurrent changes. Omit `version` only when creating a new file.
+
+## Tool Reference
+
+### Notes (user+)
+
+```
+search_notes(modified_since?)                           → []Note metadata
+get_note(note_id)                                       → Note + content
+save_note(title, content, note_id?, tags?, version?)    → Note
+delete_note(note_id)
+```
+
+- `search_notes` returns metadata only (no content). Use `get_note` to fetch content.
+- Pass `modified_since` (ISO 8601) to fetch only recently changed notes — useful for sync.
+- On update, pass `version` matching the current stored version for conflict-safe writes. Omitting `version` auto-increments and skips conflict detection.
+- Content limit: 1MB.
+
+### Todo Lists (user+)
+
+```
+list_todo_lists()                                       → []TodoList
+save_todo_list(title, list_id?, tags?, version?)        → TodoList
+delete_todo_list(list_id)                               # does not cascade-delete todos
+```
+
+### Todos (user+)
+
+```
+list_todos(list_id, status?, modified_since?)           → []Todo
+save_todo(list_id, text, todo_id?, status?, due_date?, tags?, version?)  → Todo
+delete_todo(list_id, todo_id)
+```
+
+- `status` enum: `pending` | `in_progress` | `done`
+- `due_date`: RFC3339 string
+- Use `status` filter to fetch only active items (e.g. `status="pending"` or `status="in_progress"`).
+- Use `modified_since` to sync changes since a known timestamp.
+
+### Files (user+)
+
+```
+list_files(modified_since?)                             → []File metadata
+get_file(path)                                          → File + content
+save_file(path, content, version?)                      → File
+delete_file(path)
+```
+
+- Paths are slash-separated strings (e.g. `memory/MEMORY.md`). Traversal sequences are stripped server-side.
+- Content limit: 1MB.
+- Use the `files/` namespace for arbitrary structured data: memory indexes, config snapshots, exported notes.
+
+### Admin only
+
+```
+list_users(status?)                                     → []User
+update_user(user_id, status)
+```
+
+- `status` enum for users: `pending` | `user` | `admin` | `banned`
+- Admins cannot change their own status away from `admin`.
+
+### Status (pending/banned)
+
+```
+check_status()    → account status message
+```
+
+## Memory Pattern
+
+Use `save_file` / `get_file` to persist Claude Code memory on the server. A simple layout:
+
+```
+memory/MEMORY.md          # index of topics → file paths
+memory/user.md
+memory/project_foo.md
+memory/feedback.md
+```
+
+Load `memory/MEMORY.md` at session start, then fetch individual files as needed. Save changes before ending the session. This mirrors the local `~/.claude/` memory system but stores data server-side, shared across machines.
+
+## Conflict-Safe Writes
+
+Every saved item has a `version` integer. To update safely:
+
+1. Read the item (note, file, todo, etc.) — the response includes `version`.
+2. Pass that `version` back in your `save_*` call.
+3. If another writer changed it in the meantime, the server returns a version conflict error — re-read and retry.
+
+Omitting `version` on an update silently auto-increments and skips conflict detection. This is fine for single-writer sessions; use explicit `version` when multiple clients or sessions may write the same item.


### PR DESCRIPTION
## Summary

- Adds `skill/notoriousmcp.md` — a Claude Code skill that teaches LLMs how to use the server effectively
- Covers: session-start memory load, session-end memory save, all 16 tool signatures with correct parameters, conflict-safe write pattern, memory file layout convention

## Notes

- Kept concise per the issue spec (tokens matter; this adds ~130 lines as a skill)
- No tool signatures were invented — all params derived directly from `internal/handlers/tools.go`
- Closes #12

## Test plan

- [ ] Copy to `.claude/skills/notoriousmcp.md` in a project and verify Claude Code loads it
- [ ] Verify tool signatures match `tools/list` response from a running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)