### PR TITLE
tests: clean up orphaned note in version conflict test; add TestDeleteUser (#36, #37)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -783,3 +783,33 @@ func TestSaveRefreshTokenNotFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestDeleteUser(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	u := &models.User{
+		UserID:    uid(),
+		Email:     "delete@example.com",
+		Name:      "Delete Me",
+		Status:    models.StatusPending,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := c.SaveUser(ctx, u); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	if err := c.DeleteUser(ctx, u.UserID); err != nil {
+		t.Fatalf("delete user: %v", err)
+	}
+
+	_, err := c.GetUser(ctx, u.UserID)
+	if !errors.Is(err, db.ErrNotFound) {
+		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+
+	// Deleting a non-existent user is a no-op.
+	if err := c.DeleteUser(ctx, "nonexistent-"+uid()); err != nil {
+		t.Errorf("delete non-existent user: expected no error, got %v", err)
+	}
+}

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -708,6 +708,12 @@ func TestIntegrationVersionConflict(t *testing.T) {
 		t.Fatalf("save_note v1: %+v", resp.Error)
 	}
 	noteID := extractField(t, resp.Result, "id")
+	t.Cleanup(func() {
+		doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+			"name":      "delete_note",
+			"arguments": map[string]any{"note_id": noteID},
+		})
+	})
 
 	// Update once to advance version to 2 — assert it succeeds.
 	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{


### PR DESCRIPTION
## Summary

- **#36**: `TestIntegrationVersionConflict` created a note (advanced to v2) but never deleted it, leaving a DynamoDB record + S3 object behind after every test run. Added `t.Cleanup` to delete via the handler, which covers both DB and S3.
- **#37**: Added `TestDeleteUser` to `db_test.go` — happy path (save → delete → `ErrNotFound`) and no-op on a non-existent user.

## Test plan

- [ ] `go test ./...` passes
- [ ] Integration tests pass with `DYNAMODB_ENDPOINT` set

Closes #36
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)