### PR TITLE
fix: delete previous S3 object after successful note/file update

### DIFF
--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -549,6 +550,33 @@ func TestIntegrationNoteCreateGetDelete(t *testing.T) {
 	}
 	noteID := extractField(t, resp.Result, "id")
 
+	// Capture the S3 key before updating so we can assert it's cleaned up.
+	noteV1, err := dbClient.GetNote(context.Background(), user.UserID, noteID)
+	if err != nil {
+		t.Fatalf("get note from db: %v", err)
+	}
+	oldS3Key := noteV1.S3Key
+
+	// Update.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"note_id": noteID,
+			"title":   "Integration Test Note",
+			"content": "updated content",
+			"tags":    []any{"test"},
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_note update: %+v", resp.Error)
+	}
+
+	// Old S3 key must be gone.
+	_, err = storeClient.GetContent(context.Background(), oldS3Key)
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("old s3 key %q: want ErrNotFound, got %v", oldS3Key, err)
+	}
+
 	// Get.
 	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
 		"name":      "get_note",
@@ -557,8 +585,8 @@ func TestIntegrationNoteCreateGetDelete(t *testing.T) {
 	if resp.Error != nil {
 		t.Fatalf("get_note: %+v", resp.Error)
 	}
-	if content := extractField(t, resp.Result, "content"); content != "hello world" {
-		t.Errorf("content: got %q want \"hello world\"", content)
+	if content := extractField(t, resp.Result, "content"); content != "updated content" {
+		t.Errorf("content: got %q want \"updated content\"", content)
 	}
 
 	// Delete.
@@ -639,6 +667,31 @@ func TestIntegrationFileRoundTrip(t *testing.T) {
 		t.Fatalf("save_file: %+v", resp.Error)
 	}
 
+	// Capture the S3 key before updating so we can assert it's cleaned up.
+	fileV1, err := dbClient.GetFile(context.Background(), user.UserID, path)
+	if err != nil {
+		t.Fatalf("get file from db: %v", err)
+	}
+	oldS3Key := fileV1.S3Key
+
+	// Update.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_file",
+		"arguments": map[string]any{
+			"path":    path,
+			"content": "updated contents",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_file update: %+v", resp.Error)
+	}
+
+	// Old S3 key must be gone.
+	_, err = storeClient.GetContent(context.Background(), oldS3Key)
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("old s3 key %q: want ErrNotFound, got %v", oldS3Key, err)
+	}
+
 	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
 		"name":      "get_file",
 		"arguments": map[string]any{"path": path},
@@ -646,8 +699,8 @@ func TestIntegrationFileRoundTrip(t *testing.T) {
 	if resp.Error != nil {
 		t.Fatalf("get_file: %+v", resp.Error)
 	}
-	if content := extractField(t, resp.Result, "content"); content != "file contents" {
-		t.Errorf("content: got %q", content)
+	if content := extractField(t, resp.Result, "content"); content != "updated contents" {
+		t.Errorf("content: got %q want \"updated contents\"", content)
 	}
 
 	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -99,23 +99,37 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 			CreatedAt:  now,
 			ModifiedAt: now,
 		}
-	} else {
-		version := versionArg(args)
-		if version == 0 {
-			// version omitted: auto-increment bypasses optimistic concurrency.
-			// Callers that need conflict detection must pass the current version.
-			version = existing.Version + 1
+
+		// Create path: stable S3 key, no old object to clean up.
+		if err := h.store.PutContent(ctx, f.S3Key, content); err != nil {
+			if errors.Is(err, store.ErrTooLarge) {
+				return errorResult("content exceeds 1MB limit")
+			}
+			return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 		}
-		f = &models.File{
-			Path:   filePath,
-			UserID: user.UserID,
-			// Fresh S3 key per write: same rationale as handleSaveNote.
-			S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
-			Size:       int64(len([]byte(content))),
-			Version:    version,
-			CreatedAt:  existing.CreatedAt,
-			ModifiedAt: now,
+
+		if err := h.db.SaveFile(ctx, f); err != nil {
+			return dbErrResult(err)
 		}
+
+		return jsonResult(f)
+	}
+
+	version := versionArg(args)
+	if version == 0 {
+		// version omitted: auto-increment bypasses optimistic concurrency.
+		// Callers that need conflict detection must pass the current version.
+		version = existing.Version + 1
+	}
+	f = &models.File{
+		Path:   filePath,
+		UserID: user.UserID,
+		// Fresh S3 key per write: same rationale as handleSaveNote.
+		S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
+		Size:       int64(len([]byte(content))),
+		Version:    version,
+		CreatedAt:  existing.CreatedAt,
+		ModifiedAt: now,
 	}
 
 	// S3 write precedes DynamoDB write; on DB conflict the new S3 object is
@@ -129,6 +143,12 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 
 	if err := h.db.SaveFile(ctx, f); err != nil {
 		return dbErrResult(err)
+	}
+
+	// DB write succeeded; delete the now-unreferenced previous S3 object.
+	// Log on failure but don't surface the error — the save already succeeded.
+	if err := h.store.DeleteContent(ctx, existing.S3Key); err != nil {
+		log.Printf("mcp: save file %s: cleanup old s3 key %s: %v", filePath, existing.S3Key, err)
 	}
 
 	return jsonResult(f)

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -86,7 +86,8 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 	if dbErr != nil && !errors.Is(dbErr, db.ErrNotFound) {
 		return dbErrResult(dbErr)
 	}
-
+	// existing is nil iff GetFile returned ErrNotFound; the block below always returns,
+	// so all code after it can safely dereference existing.
 	if existing == nil {
 		f = &models.File{
 			Path:   filePath,

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -102,11 +102,31 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 			CreatedAt:  existing.CreatedAt,
 			ModifiedAt: now,
 		}
+
+		// S3 write precedes DynamoDB write; on DB conflict the new S3 object is
+		// orphaned but the previous version's object is untouched (version-stamped
+		// keys ensure writes never overwrite earlier content).
+		if err := h.store.PutContent(ctx, note.S3Key, content); err != nil {
+			if errors.Is(err, store.ErrTooLarge) {
+				return errorResult("content exceeds 1MB limit")
+			}
+			return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+		}
+
+		if err := h.db.SaveNote(ctx, note); err != nil {
+			return dbErrResult(err)
+		}
+
+		// DB write succeeded; delete the now-unreferenced previous S3 object.
+		// Log on failure but don't surface the error — the save already succeeded.
+		if err := h.store.DeleteContent(ctx, existing.S3Key); err != nil {
+			log.Printf("mcp: save note %s: cleanup old s3 key %s: %v", noteID, existing.S3Key, err)
+		}
+
+		return jsonResult(note)
 	}
 
-	// S3 write precedes DynamoDB write; on DB conflict the new S3 object is
-	// orphaned but the previous version's object is untouched (version-stamped
-	// keys ensure writes never overwrite earlier content).
+	// Create path: stable S3 key, no old object to clean up.
 	if err := h.store.PutContent(ctx, note.S3Key, content); err != nil {
 		if errors.Is(err, store.ErrTooLarge) {
 			return errorResult("content exceeds 1MB limit")


### PR DESCRIPTION
Closes #39

## Summary

- On note/file update, delete the now-unreferenced previous S3 object after the DynamoDB write succeeds
- Failure to delete is logged but not surfaced — the save already succeeded and the old key is unreachable
- Create path is unchanged (stable key, no prior object to clean up)

## Test plan

- [ ] Run integration tests against local dev stack: `DYNAMODB_ENDPOINT=http://localhost:8000 TABLE_NAME=notoriousmcp S3_ENDPOINT=http://localhost:9000 S3_BUCKET=notoriousmcp-local AWS_ACCESS_KEY_ID=localuser AWS_SECRET_ACCESS_KEY=localpassword AWS_DEFAULT_REGION=us-east-1 go test ./internal/handlers/ -count=1`
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)