### PR TITLE
feat: per-user storage and monthly transfer caps

### DIFF
--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/pwntato/notoriousmcp/internal/auth"
@@ -42,7 +43,10 @@ func main() {
 	}
 
 	authHandler := auth.New(authCfg, dbClient)
-	mcpHandler := handlers.New(dbClient, storeClient)
+	mcpHandler := handlers.New(dbClient, storeClient, handlers.Config{
+		DefaultStorageCap:  int64EnvOrDefault("DEFAULT_STORAGE_CAP_BYTES", handlers.DefaultStorageCapBytes),
+		DefaultTransferCap: int64EnvOrDefault("DEFAULT_TRANSFER_CAP_BYTES", handlers.DefaultTransferCapBytes),
+	})
 
 	mux := http.NewServeMux()
 	authHandler.RegisterRoutes(mux)
@@ -79,6 +83,19 @@ func envOrDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func int64EnvOrDefault(key string, def int64) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		log.Printf("warning: %s=%q is not a valid int64, using default %d", key, v, def)
+		return def
+	}
+	return n
 }
 
 // filterEmpty removes empty strings. Needed because strings.Split("", ",") returns

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/pwntato/notoriousmcp/internal/auth"
+	"github.com/pwntato/notoriousmcp/internal/config"
 	"github.com/pwntato/notoriousmcp/internal/db"
 	"github.com/pwntato/notoriousmcp/internal/handlers"
 	"github.com/pwntato/notoriousmcp/internal/store"
@@ -44,8 +44,8 @@ func main() {
 
 	authHandler := auth.New(authCfg, dbClient)
 	mcpHandler := handlers.New(dbClient, storeClient, handlers.Config{
-		DefaultStorageCap:  int64EnvOrDefault("DEFAULT_STORAGE_CAP_BYTES", handlers.DefaultStorageCapBytes),
-		DefaultTransferCap: int64EnvOrDefault("DEFAULT_TRANSFER_CAP_BYTES", handlers.DefaultTransferCapBytes),
+		DefaultStorageCap:  config.Int64EnvOrDefault("DEFAULT_STORAGE_CAP_BYTES", handlers.DefaultStorageCapBytes),
+		DefaultTransferCap: config.Int64EnvOrDefault("DEFAULT_TRANSFER_CAP_BYTES", handlers.DefaultTransferCapBytes),
 	})
 
 	mux := http.NewServeMux()
@@ -83,19 +83,6 @@ func envOrDefault(key, def string) string {
 		return v
 	}
 	return def
-}
-
-func int64EnvOrDefault(key string, def int64) int64 {
-	v := os.Getenv(key)
-	if v == "" {
-		return def
-	}
-	n, err := strconv.ParseInt(v, 10, 64)
-	if err != nil {
-		log.Printf("warning: %s=%q is not a valid int64, using default %d", key, v, def)
-		return def
-	}
-	return n
 }
 
 // filterEmpty removes empty strings. Needed because strings.Split("", ",") returns

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 
 	"github.com/pwntato/notoriousmcp/internal/auth"
+	internalconfig "github.com/pwntato/notoriousmcp/internal/config"
 	"github.com/pwntato/notoriousmcp/internal/db"
 	"github.com/pwntato/notoriousmcp/internal/handlers"
 	"github.com/pwntato/notoriousmcp/internal/store"
@@ -73,8 +73,8 @@ func init() {
 
 	authHandler := auth.New(authCfg, dbClient)
 	mcpHandler := handlers.New(dbClient, storeClient, handlers.Config{
-		DefaultStorageCap:  int64EnvOrDefault("DEFAULT_STORAGE_CAP_BYTES", handlers.DefaultStorageCapBytes),
-		DefaultTransferCap: int64EnvOrDefault("DEFAULT_TRANSFER_CAP_BYTES", handlers.DefaultTransferCapBytes),
+		DefaultStorageCap:  internalconfig.Int64EnvOrDefault("DEFAULT_STORAGE_CAP_BYTES", handlers.DefaultStorageCapBytes),
+		DefaultTransferCap: internalconfig.Int64EnvOrDefault("DEFAULT_TRANSFER_CAP_BYTES", handlers.DefaultTransferCapBytes),
 	})
 
 	mux := http.NewServeMux()
@@ -172,19 +172,6 @@ func mustEnv(key string) string {
 		log.Fatalf("required env var %s is not set", key)
 	}
 	return v
-}
-
-func int64EnvOrDefault(key string, def int64) int64 {
-	v := os.Getenv(key)
-	if v == "" {
-		return def
-	}
-	n, err := strconv.ParseInt(v, 10, 64)
-	if err != nil {
-		log.Printf("warning: %s=%q is not a valid int64, using default %d", key, v, def)
-		return def
-	}
-	return n
 }
 
 func filterEmpty(ss []string) []string {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -71,7 +72,10 @@ func init() {
 	}
 
 	authHandler := auth.New(authCfg, dbClient)
-	mcpHandler := handlers.New(dbClient, storeClient)
+	mcpHandler := handlers.New(dbClient, storeClient, handlers.Config{
+		DefaultStorageCap:  int64EnvOrDefault("DEFAULT_STORAGE_CAP_BYTES", handlers.DefaultStorageCapBytes),
+		DefaultTransferCap: int64EnvOrDefault("DEFAULT_TRANSFER_CAP_BYTES", handlers.DefaultTransferCapBytes),
+	})
 
 	mux := http.NewServeMux()
 	authHandler.RegisterRoutes(mux)
@@ -168,6 +172,19 @@ func mustEnv(key string) string {
 		log.Fatalf("required env var %s is not set", key)
 	}
 	return v
+}
+
+func int64EnvOrDefault(key string, def int64) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		log.Printf("warning: %s=%q is not a valid int64, using default %d", key, v, def)
+		return def
+	}
+	return n
 }
 
 func filterEmpty(ss []string) []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
+// Int64EnvOrDefault reads an environment variable as int64. Returns def if the
+// variable is unset or unparseable (logs a warning on parse failure).
+func Int64EnvOrDefault(key string, def int64) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		log.Printf("warning: %s=%q is not a valid int64, using default %d", key, v, def)
+		return def
+	}
+	return n
+}

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -6,4 +6,6 @@ var (
 	ErrNotFound        = errors.New("not found")
 	ErrVersionConflict = errors.New("version conflict")
 	ErrNoRefreshToken  = errors.New("no refresh token")
+	ErrStorageCap      = errors.New("storage cap reached")
+	ErrTransferCap     = errors.New("transfer cap reached")
 )

--- a/internal/db/notes.go
+++ b/internal/db/notes.go
@@ -22,6 +22,7 @@ type noteRecord struct {
 	Title      string   `dynamodbav:"Title"`
 	Tags       []string `dynamodbav:"Tags"`
 	S3Key      string   `dynamodbav:"S3Key"`
+	Size       int64    `dynamodbav:"Size"`
 	Version    int      `dynamodbav:"Version"`
 	CreatedAt  string   `dynamodbav:"CreatedAt"`
 	ModifiedAt string   `dynamodbav:"ModifiedAt"`
@@ -63,6 +64,7 @@ func (c *Client) SaveNote(ctx context.Context, n *models.Note) error {
 			"UserID":     &types.AttributeValueMemberS{Value: n.UserID},
 			"Title":      &types.AttributeValueMemberS{Value: n.Title},
 			"S3Key":      &types.AttributeValueMemberS{Value: n.S3Key},
+			"Size":       &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", n.Size)},
 			"Version":    &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", n.Version)},
 			"CreatedAt":  &types.AttributeValueMemberS{Value: n.CreatedAt.UTC().Format(isoFormat)},
 			"ModifiedAt": &types.AttributeValueMemberS{Value: modAt},
@@ -154,6 +156,7 @@ func noteFromItem(item map[string]types.AttributeValue) (*models.Note, error) {
 		Title:   rec.Title,
 		Tags:    rec.Tags,
 		S3Key:   rec.S3Key,
+		Size:    rec.Size,
 		Version: rec.Version,
 	}
 	var err error

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -243,56 +242,42 @@ func (c *Client) ListUsers(ctx context.Context, status *models.UserStatus) ([]mo
 	return users, nil
 }
 
-// UpdateUserCaps sets per-user cap overrides. A non-nil value sets the cap;
-// nil removes the per-user override (restoring the server default).
+// UpdateStorageCap sets or clears the per-user storage cap override. A non-nil
+// value sets the cap; nil removes the override (restoring the server default).
 // Returns ErrNotFound if the user does not exist.
-func (c *Client) UpdateUserCaps(ctx context.Context, userID string, storageCap, transferCap *int64) error {
-	var setParts, removeParts []string
-	names := map[string]string{}
-	vals := map[string]types.AttributeValue{}
+func (c *Client) UpdateStorageCap(ctx context.Context, userID string, cap *int64) error {
+	return updateSingleCap(ctx, c, userID, "StorageCapBytes", "#sc", ":sc", cap, "update storage cap")
+}
 
-	if storageCap != nil {
-		setParts = append(setParts, "#sc = :sc")
-		names["#sc"] = "StorageCapBytes"
-		vals[":sc"] = &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", *storageCap)}
-	} else {
-		removeParts = append(removeParts, "StorageCapBytes")
-	}
+// UpdateTransferCap sets or clears the per-user monthly transfer cap override.
+// A non-nil value sets the cap; nil removes the override.
+// Returns ErrNotFound if the user does not exist.
+func (c *Client) UpdateTransferCap(ctx context.Context, userID string, cap *int64) error {
+	return updateSingleCap(ctx, c, userID, "TransferCapBytes", "#tc", ":tc", cap, "update transfer cap")
+}
 
-	if transferCap != nil {
-		setParts = append(setParts, "#tc = :tc")
-		names["#tc"] = "TransferCapBytes"
-		vals[":tc"] = &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", *transferCap)}
-	} else {
-		removeParts = append(removeParts, "TransferCapBytes")
-	}
-
+// updateSingleCap is the shared implementation for UpdateStorageCap and UpdateTransferCap.
+// It sets the named attribute when cap is non-nil, or REMOVEs it when nil.
+func updateSingleCap(ctx context.Context, c *Client, userID, attr, nameKey, valKey string, cap *int64, opName string) error {
 	var expr string
-	if len(setParts) > 0 {
-		expr += "SET " + strings.Join(setParts, ", ")
-	}
-	if len(removeParts) > 0 {
-		if expr != "" {
-			expr += " "
-		}
-		expr += "REMOVE " + strings.Join(removeParts, ", ")
-	}
-
 	input := &dynamodb.UpdateItemInput{
 		TableName: aws.String(c.tableName),
 		Key: map[string]types.AttributeValue{
 			"PK": &types.AttributeValueMemberS{Value: pk(userID)},
 			"SK": &types.AttributeValueMemberS{Value: profileSK()},
 		},
-		UpdateExpression:    aws.String(expr),
 		ConditionExpression: aws.String("attribute_exists(PK)"),
 	}
-	if len(names) > 0 {
-		input.ExpressionAttributeNames = names
+	if cap != nil {
+		expr = "SET " + nameKey + " = " + valKey
+		input.ExpressionAttributeNames = map[string]string{nameKey: attr}
+		input.ExpressionAttributeValues = map[string]types.AttributeValue{
+			valKey: &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", *cap)},
+		}
+	} else {
+		expr = "REMOVE " + attr
 	}
-	if len(vals) > 0 {
-		input.ExpressionAttributeValues = vals
-	}
+	input.UpdateExpression = aws.String(expr)
 
 	_, err := c.ddb.UpdateItem(ctx, input)
 	if err != nil {
@@ -300,7 +285,7 @@ func (c *Client) UpdateUserCaps(ctx context.Context, userID string, storageCap, 
 		if errors.As(err, &cfe) {
 			return ErrNotFound
 		}
-		return fmt.Errorf("update user caps: %w", err)
+		return fmt.Errorf("%s: %w", opName, err)
 	}
 	return nil
 }

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -275,6 +275,9 @@ func updateSingleCap(ctx context.Context, c *Client, userID, attr, nameKey, valK
 			valKey: &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", *cap)},
 		}
 	} else {
+		// REMOVE uses the raw attribute name rather than an expression attribute
+		// name. This is safe because attr is hardcoded ("StorageCapBytes" or
+		// "TransferCapBytes"), neither of which is a DynamoDB reserved word.
 		expr = "REMOVE " + attr
 	}
 	input.UpdateExpression = aws.String(expr)

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -353,8 +354,8 @@ func (c *Client) AddTransferUsed(ctx context.Context, userID, month string, delt
 	if !ok {
 		return 0, fmt.Errorf("add transfer used: unexpected type for BytesOut")
 	}
-	var total int64
-	if _, err := fmt.Sscanf(n.Value, "%d", &total); err != nil {
+	total, err := strconv.ParseInt(n.Value, 10, 64)
+	if err != nil {
 		return 0, fmt.Errorf("add transfer used: parse BytesOut: %w", err)
 	}
 	return total, nil
@@ -385,8 +386,8 @@ func (c *Client) GetTransferUsed(ctx context.Context, userID, month string) (int
 	if !ok {
 		return 0, nil
 	}
-	var total int64
-	if _, err := fmt.Sscanf(n.Value, "%d", &total); err != nil {
+	total, err := strconv.ParseInt(n.Value, 10, 64)
+	if err != nil {
 		return 0, fmt.Errorf("get transfer used: parse BytesOut: %w", err)
 	}
 	return total, nil

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -13,13 +14,16 @@ import (
 )
 
 type userRecord struct {
-	PK        string            `dynamodbav:"PK"`
-	SK        string            `dynamodbav:"SK"`
-	UserID    string            `dynamodbav:"UserID"`
-	Email     string            `dynamodbav:"Email"`
-	Name      string            `dynamodbav:"Name"`
-	Status    models.UserStatus `dynamodbav:"Status"`
-	CreatedAt string            `dynamodbav:"CreatedAt"`
+	PK               string            `dynamodbav:"PK"`
+	SK               string            `dynamodbav:"SK"`
+	UserID           string            `dynamodbav:"UserID"`
+	Email            string            `dynamodbav:"Email"`
+	Name             string            `dynamodbav:"Name"`
+	Status           models.UserStatus `dynamodbav:"Status"`
+	CreatedAt        string            `dynamodbav:"CreatedAt"`
+	StorageUsedBytes int64             `dynamodbav:"StorageUsedBytes"`
+	StorageCapBytes  *int64            `dynamodbav:"StorageCapBytes,omitempty"`
+	TransferCapBytes *int64            `dynamodbav:"TransferCapBytes,omitempty"`
 }
 
 // GetUser retrieves a user profile by user ID.
@@ -47,7 +51,9 @@ func (c *Client) GetUser(ctx context.Context, userID string) (*models.User, erro
 }
 
 // SaveUser upserts a user profile. RefreshToken is not written by this
-// function — use SaveRefreshToken for that.
+// function — use SaveRefreshToken for that. Cap fields (StorageCapBytes,
+// TransferCapBytes) are only written when non-nil; use UpdateUserCaps to
+// set them. StorageUsedBytes is not written here — use AddStorageUsed.
 func (c *Client) SaveUser(ctx context.Context, u *models.User) error {
 	_, err := c.ddb.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: aws.String(c.tableName),
@@ -55,13 +61,14 @@ func (c *Client) SaveUser(ctx context.Context, u *models.User) error {
 			"PK": &types.AttributeValueMemberS{Value: pk(u.UserID)},
 			"SK": &types.AttributeValueMemberS{Value: profileSK()},
 		},
-		UpdateExpression: aws.String("SET #uid = :uid, #email = :email, #name = :name, #status = :status, #createdAt = if_not_exists(#createdAt, :createdAt)"),
+		UpdateExpression: aws.String("SET #uid = :uid, #email = :email, #name = :name, #status = :status, #createdAt = if_not_exists(#createdAt, :createdAt), #storageUsed = if_not_exists(#storageUsed, :zero)"),
 		ExpressionAttributeNames: map[string]string{
-			"#uid":       "UserID",
-			"#email":     "Email",
-			"#name":      "Name",
-			"#status":    "Status",
-			"#createdAt": "CreatedAt",
+			"#uid":         "UserID",
+			"#email":       "Email",
+			"#name":        "Name",
+			"#status":      "Status",
+			"#createdAt":   "CreatedAt",
+			"#storageUsed": "StorageUsedBytes",
 		},
 		ExpressionAttributeValues: map[string]types.AttributeValue{
 			":uid":       &types.AttributeValueMemberS{Value: u.UserID},
@@ -69,6 +76,7 @@ func (c *Client) SaveUser(ctx context.Context, u *models.User) error {
 			":name":      &types.AttributeValueMemberS{Value: u.Name},
 			":status":    &types.AttributeValueMemberS{Value: string(u.Status)},
 			":createdAt": &types.AttributeValueMemberS{Value: u.CreatedAt.UTC().Format(isoFormat)},
+			":zero":      &types.AttributeValueMemberN{Value: "0"},
 		},
 	})
 	if err != nil {
@@ -235,12 +243,176 @@ func (c *Client) ListUsers(ctx context.Context, status *models.UserStatus) ([]mo
 	return users, nil
 }
 
+// UpdateUserCaps sets per-user cap overrides. A non-nil value sets the cap;
+// nil removes the per-user override (restoring the server default).
+// Returns ErrNotFound if the user does not exist.
+func (c *Client) UpdateUserCaps(ctx context.Context, userID string, storageCap, transferCap *int64) error {
+	var setParts, removeParts []string
+	names := map[string]string{}
+	vals := map[string]types.AttributeValue{}
+
+	if storageCap != nil {
+		setParts = append(setParts, "#sc = :sc")
+		names["#sc"] = "StorageCapBytes"
+		vals[":sc"] = &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", *storageCap)}
+	} else {
+		removeParts = append(removeParts, "StorageCapBytes")
+	}
+
+	if transferCap != nil {
+		setParts = append(setParts, "#tc = :tc")
+		names["#tc"] = "TransferCapBytes"
+		vals[":tc"] = &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", *transferCap)}
+	} else {
+		removeParts = append(removeParts, "TransferCapBytes")
+	}
+
+	var expr string
+	if len(setParts) > 0 {
+		expr += "SET " + strings.Join(setParts, ", ")
+	}
+	if len(removeParts) > 0 {
+		if expr != "" {
+			expr += " "
+		}
+		expr += "REMOVE " + strings.Join(removeParts, ", ")
+	}
+
+	input := &dynamodb.UpdateItemInput{
+		TableName: aws.String(c.tableName),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: pk(userID)},
+			"SK": &types.AttributeValueMemberS{Value: profileSK()},
+		},
+		UpdateExpression:    aws.String(expr),
+		ConditionExpression: aws.String("attribute_exists(PK)"),
+	}
+	if len(names) > 0 {
+		input.ExpressionAttributeNames = names
+	}
+	if len(vals) > 0 {
+		input.ExpressionAttributeValues = vals
+	}
+
+	_, err := c.ddb.UpdateItem(ctx, input)
+	if err != nil {
+		var cfe *types.ConditionalCheckFailedException
+		if errors.As(err, &cfe) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("update user caps: %w", err)
+	}
+	return nil
+}
+
+// AddStorageUsed atomically adjusts StorageUsedBytes on the user's PROFILE item
+// by delta (positive to add, negative to subtract). Returns ErrNotFound if the
+// user does not exist.
+func (c *Client) AddStorageUsed(ctx context.Context, userID string, delta int64) error {
+	_, err := c.ddb.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(c.tableName),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: pk(userID)},
+			"SK": &types.AttributeValueMemberS{Value: profileSK()},
+		},
+		UpdateExpression:    aws.String("ADD StorageUsedBytes :delta"),
+		ConditionExpression: aws.String("attribute_exists(PK)"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":delta": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", delta)},
+		},
+	})
+	if err != nil {
+		var cfe *types.ConditionalCheckFailedException
+		if errors.As(err, &cfe) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("add storage used: %w", err)
+	}
+	return nil
+}
+
+// transferSK returns the sort key for a per-user monthly transfer record.
+func transferSK(month string) string { return "TRANSFER#" + month }
+
+// AddTransferUsed atomically increments BytesOut on the TRANSFER#YYYY-MM item
+// for the given user and month, and returns the new total. Sets a 60-day TTL
+// on the first write of each month so old records self-clean.
+func (c *Client) AddTransferUsed(ctx context.Context, userID, month string, delta int64, ttlUnix int64) (int64, error) {
+	out, err := c.ddb.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(c.tableName),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: pk(userID)},
+			"SK": &types.AttributeValueMemberS{Value: transferSK(month)},
+		},
+		UpdateExpression: aws.String("ADD BytesOut :delta SET #ttl = if_not_exists(#ttl, :ttl)"),
+		ExpressionAttributeNames: map[string]string{
+			"#ttl": "TTL",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":delta": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", delta)},
+			":ttl":   &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", ttlUnix)},
+		},
+		ReturnValues: types.ReturnValueUpdatedNew,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("add transfer used: %w", err)
+	}
+	attr, ok := out.Attributes["BytesOut"]
+	if !ok {
+		return 0, fmt.Errorf("add transfer used: BytesOut not in response")
+	}
+	n, ok := attr.(*types.AttributeValueMemberN)
+	if !ok {
+		return 0, fmt.Errorf("add transfer used: unexpected type for BytesOut")
+	}
+	var total int64
+	if _, err := fmt.Sscanf(n.Value, "%d", &total); err != nil {
+		return 0, fmt.Errorf("add transfer used: parse BytesOut: %w", err)
+	}
+	return total, nil
+}
+
+// GetTransferUsed returns the current BytesOut total for a user in a given month.
+// Returns 0 (not ErrNotFound) if no transfer record exists yet.
+func (c *Client) GetTransferUsed(ctx context.Context, userID, month string) (int64, error) {
+	out, err := c.ddb.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(c.tableName),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: pk(userID)},
+			"SK": &types.AttributeValueMemberS{Value: transferSK(month)},
+		},
+		ProjectionExpression: aws.String("BytesOut"),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("get transfer used: %w", err)
+	}
+	if out.Item == nil {
+		return 0, nil
+	}
+	attr, ok := out.Item["BytesOut"]
+	if !ok {
+		return 0, nil
+	}
+	n, ok := attr.(*types.AttributeValueMemberN)
+	if !ok {
+		return 0, nil
+	}
+	var total int64
+	if _, err := fmt.Sscanf(n.Value, "%d", &total); err != nil {
+		return 0, fmt.Errorf("get transfer used: parse BytesOut: %w", err)
+	}
+	return total, nil
+}
+
 func userFromRecord(rec *userRecord) (*models.User, error) {
 	u := &models.User{
-		UserID: rec.UserID,
-		Email:  rec.Email,
-		Name:   rec.Name,
-		Status: rec.Status,
+		UserID:           rec.UserID,
+		Email:            rec.Email,
+		Name:             rec.Name,
+		Status:           rec.Status,
+		StorageUsedBytes: rec.StorageUsedBytes,
+		StorageCapBytes:  rec.StorageCapBytes,
+		TransferCapBytes: rec.TransferCapBytes,
 	}
 	var err error
 	if u.CreatedAt, err = parseTime(rec.CreatedAt); err != nil {

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -914,16 +914,17 @@ func TestIntegrationFileStorageCapEnforced(t *testing.T) {
 
 func TestIntegrationStorageDecrementedOnDelete(t *testing.T) {
 	dbClient, storeClient := newTestClients(t)
-	admin := saveIntegrationUser(t, dbClient, models.StatusAdmin)
 	user := saveIntegrationUser(t, dbClient, models.StatusUser)
 	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	content := "some content for delete decrement test"
 
 	// Save a note to establish some storage usage.
 	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
 		"name": "save_note",
 		"arguments": map[string]any{
 			"title":   "Delete Decrement Test",
-			"content": "some content",
+			"content": content,
 		},
 	})
 	if resp.Error != nil {
@@ -931,8 +932,16 @@ func TestIntegrationStorageDecrementedOnDelete(t *testing.T) {
 	}
 	noteID := extractField(t, resp.Result, "id")
 
-	// Capture storage usage after save via list_users.
-	usageBefore := getStorageUsedPct(t, h, admin.UserID, user.UserID)
+	// Capture the raw StorageUsedBytes from DynamoDB directly — avoids the
+	// integer-percentage resolution loss at 1GB default cap scale.
+	u, err := dbClient.GetUser(context.Background(), user.UserID)
+	if err != nil {
+		t.Fatalf("get user after save: %v", err)
+	}
+	usedAfterSave := u.StorageUsedBytes
+	if usedAfterSave == 0 {
+		t.Fatal("StorageUsedBytes is 0 after save_note — accounting not working")
+	}
 
 	// Delete the note.
 	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
@@ -943,37 +952,14 @@ func TestIntegrationStorageDecrementedOnDelete(t *testing.T) {
 		t.Fatalf("delete_note: %+v", resp.Error)
 	}
 
-	// Storage usage should be lower (or zero) after delete.
-	usageAfter := getStorageUsedPct(t, h, admin.UserID, user.UserID)
-	if usageAfter >= usageBefore {
-		t.Errorf("storage_used_pct: want < %d after delete, got %d", usageBefore, usageAfter)
+	// StorageUsedBytes should be back to 0 (only note for this user).
+	u, err = dbClient.GetUser(context.Background(), user.UserID)
+	if err != nil {
+		t.Fatalf("get user after delete: %v", err)
 	}
-}
-
-// getStorageUsedPct returns the storage_used_pct for targetUserID from list_users.
-func getStorageUsedPct(t *testing.T, h http.Handler, adminUserID, targetUserID string) int {
-	t.Helper()
-	resp := doIntegrationRequest(t, h, adminUserID, "tools/call", map[string]any{
-		"name":      "list_users",
-		"arguments": map[string]any{},
-	})
-	if resp.Error != nil {
-		t.Fatalf("list_users: %+v", resp.Error)
+	if u.StorageUsedBytes != 0 {
+		t.Errorf("StorageUsedBytes: want 0 after delete, got %d", u.StorageUsedBytes)
 	}
-	text := firstContentText(t, resp.Result)
-	var users []map[string]any
-	if err := json.Unmarshal([]byte(text), &users); err != nil {
-		t.Fatalf("unmarshal users: %v", err)
-	}
-	for _, u := range users {
-		if u["user_id"] == targetUserID {
-			if pct, ok := u["storage_used_pct"].(float64); ok {
-				return int(pct)
-			}
-		}
-	}
-	t.Fatalf("user %s not found in list_users", targetUserID)
-	return 0
 }
 
 func TestIntegrationTransferCapEnforced(t *testing.T) {

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -1212,6 +1212,62 @@ func TestIntegrationStorageCapEnforcedOnUpdate(t *testing.T) {
 	}
 }
 
+func TestIntegrationFileStorageCapEnforcedOnUpdate(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	// Cap is 50 bytes — enough for the initial save but not the larger update.
+	h := newIntegrationHandlerWithConfig(t, dbClient, storeClient, handlers.Config{
+		DefaultStorageCap:  50,
+		DefaultTransferCap: handlers.DefaultTransferCapBytes,
+	})
+
+	filePath := "test/cap-update-" + newTestUserID() + ".txt"
+
+	// Create a small file that fits under the cap.
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_file",
+		"arguments": map[string]any{
+			"path":    filePath,
+			"content": "small",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_file (create): %+v", resp.Error)
+	}
+	var createResult struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &createResult); err != nil {
+		t.Fatalf("unmarshal create: %v", err)
+	}
+	if createResult.IsError {
+		t.Fatalf("save_file (create) unexpectedly blocked: %s", firstContentText(t, resp.Result))
+	}
+	t.Cleanup(func() {
+		doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+			"name":      "delete_file",
+			"arguments": map[string]any{"path": filePath},
+		})
+	})
+
+	// Update with content large enough to push the total over the 50-byte cap.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_file",
+		"arguments": map[string]any{
+			"path":    filePath,
+			"content": "this updated content is definitely more than fifty bytes total",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error on update: %+v", resp.Error)
+	}
+	var updateResult struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &updateResult); err != nil {
+		t.Fatalf("unmarshal update: %v", err)
+	}
+	if !updateResult.IsError {
+		t.Error("expected isError=true when file update pushes past storage cap")
+	}
+}
+
 func TestIntegrationPerUserTransferCapOverride(t *testing.T) {
 	dbClient, storeClient := newTestClients(t)
 	admin := saveIntegrationUser(t, dbClient, models.StatusAdmin)

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -1009,6 +1009,51 @@ func TestIntegrationTransferCapEnforced(t *testing.T) {
 	}
 }
 
+func TestIntegrationFileTransferCapEnforced(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	// Transfer cap is 1 byte — any real get response will exceed it.
+	h := newIntegrationHandlerWithConfig(t, dbClient, storeClient, handlers.Config{
+		DefaultStorageCap:  handlers.DefaultStorageCapBytes,
+		DefaultTransferCap: 1,
+	})
+
+	// Create a file (doesn't hit transfer cap).
+	filePath := "test/transfer-cap-" + newTestUserID() + ".txt"
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_file",
+		"arguments": map[string]any{
+			"path":    filePath,
+			"content": "hello",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_file: %+v", resp.Error)
+	}
+	t.Cleanup(func() {
+		doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+			"name":      "delete_file",
+			"arguments": map[string]any{"path": filePath},
+		})
+	})
+
+	// get_file must be blocked by the transfer cap.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "get_file",
+		"arguments": map[string]any{"path": filePath},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %+v", resp.Error)
+	}
+	var result struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true when file transfer cap exceeded")
+	}
+}
+
 func TestIntegrationUsageVisibleInListUsers(t *testing.T) {
 	dbClient, storeClient := newTestClients(t)
 	admin := saveIntegrationUser(t, dbClient, models.StatusAdmin)

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -991,8 +991,8 @@ func TestIntegrationUsageVisibleInListUsers(t *testing.T) {
 				t.Error("transfer_used_pct missing from list_users response")
 			}
 			// Storage should be > 0 after saving a note.
-			if pct, ok := u["storage_used_pct"].(float64); !ok || pct < 0 {
-				t.Errorf("storage_used_pct: unexpected value %v", u["storage_used_pct"])
+			if pct, ok := u["storage_used_pct"].(float64); !ok || pct <= 0 {
+				t.Errorf("storage_used_pct: want > 0 after save, got %v", u["storage_used_pct"])
 			}
 		}
 	}

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -1001,6 +1001,81 @@ func TestIntegrationUsageVisibleInListUsers(t *testing.T) {
 	}
 }
 
+func TestIntegrationPerUserCapOverride(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	admin := saveIntegrationUser(t, dbClient, models.StatusAdmin)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	// Set a tiny storage cap (10 bytes) via update_user — no status change.
+	resp := doIntegrationRequest(t, h, admin.UserID, "tools/call", map[string]any{
+		"name": "update_user",
+		"arguments": map[string]any{
+			"user_id":           user.UserID,
+			"storage_cap_bytes": float64(10),
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("update_user (set cap): %+v", resp.Error)
+	}
+	var updateResult struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &updateResult); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if updateResult.IsError {
+		t.Fatalf("update_user (set cap): unexpected isError=true: %s", firstContentText(t, resp.Result))
+	}
+
+	// save_note must be blocked by the tiny per-user cap.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Cap Override Test",
+			"content": "this is more than 10 bytes of content",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %+v", resp.Error)
+	}
+	var saveResult struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &saveResult); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !saveResult.IsError {
+		t.Error("expected isError=true when per-user storage cap exceeded")
+	}
+
+	// Clear the cap via -1; save should now succeed.
+	resp = doIntegrationRequest(t, h, admin.UserID, "tools/call", map[string]any{
+		"name": "update_user",
+		"arguments": map[string]any{
+			"user_id":           user.UserID,
+			"storage_cap_bytes": float64(-1),
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("update_user (clear cap): %+v", resp.Error)
+	}
+
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Cap Override Test",
+			"content": "this is more than 10 bytes of content",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_note after cap cleared: %+v", resp.Error)
+	}
+	noteID := extractField(t, resp.Result, "id")
+	t.Cleanup(func() {
+		doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+			"name":      "delete_note",
+			"arguments": map[string]any{"note_id": noteID},
+		})
+	})
+}
+
 // ---- test helpers ----
 
 type toolEntry struct {

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -946,7 +946,7 @@ func TestIntegrationUsageVisibleInListUsers(t *testing.T) {
 	user := saveIntegrationUser(t, dbClient, models.StatusUser)
 	h := newIntegrationHandler(t, dbClient, storeClient)
 
-	// Save a note to accumulate some storage usage.
+	// Save a note to accumulate storage usage.
 	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
 		"name": "save_note",
 		"arguments": map[string]any{
@@ -965,7 +965,16 @@ func TestIntegrationUsageVisibleInListUsers(t *testing.T) {
 		})
 	})
 
-	// Admin lists users — find our user and check usage fields are present.
+	// Fetch the note to accumulate transfer usage.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "get_note",
+		"arguments": map[string]any{"note_id": noteID},
+	})
+	if resp.Error != nil {
+		t.Fatalf("get_note: %+v", resp.Error)
+	}
+
+	// Admin lists users — find our user and verify both usage percentages are > 0.
 	resp = doIntegrationRequest(t, h, admin.UserID, "tools/call", map[string]any{
 		"name":      "list_users",
 		"arguments": map[string]any{},
@@ -990,9 +999,11 @@ func TestIntegrationUsageVisibleInListUsers(t *testing.T) {
 			if _, ok := u["transfer_used_pct"]; !ok {
 				t.Error("transfer_used_pct missing from list_users response")
 			}
-			// Storage should be > 0 after saving a note.
 			if pct, ok := u["storage_used_pct"].(float64); !ok || pct <= 0 {
 				t.Errorf("storage_used_pct: want > 0 after save, got %v", u["storage_used_pct"])
+			}
+			if pct, ok := u["transfer_used_pct"].(float64); !ok || pct <= 0 {
+				t.Errorf("transfer_used_pct: want > 0 after get_note, got %v", u["transfer_used_pct"])
 			}
 		}
 	}
@@ -1074,6 +1085,87 @@ func TestIntegrationPerUserCapOverride(t *testing.T) {
 			"arguments": map[string]any{"note_id": noteID},
 		})
 	})
+}
+
+func TestIntegrationPerUserTransferCapOverride(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	admin := saveIntegrationUser(t, dbClient, models.StatusAdmin)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	// Create a note first (no cap concerns on write).
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Transfer Cap Override Test",
+			"content": "this is more than one byte of content",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_note: %+v", resp.Error)
+	}
+	noteID := extractField(t, resp.Result, "id")
+	t.Cleanup(func() {
+		doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+			"name":      "delete_note",
+			"arguments": map[string]any{"note_id": noteID},
+		})
+	})
+
+	// Set a 1-byte transfer cap via update_user (no status change).
+	resp = doIntegrationRequest(t, h, admin.UserID, "tools/call", map[string]any{
+		"name": "update_user",
+		"arguments": map[string]any{
+			"user_id":            user.UserID,
+			"transfer_cap_bytes": float64(1),
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("update_user (set transfer cap): %+v", resp.Error)
+	}
+
+	// get_note must be blocked by the tiny per-user transfer cap.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "get_note",
+		"arguments": map[string]any{"note_id": noteID},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %+v", resp.Error)
+	}
+	var result struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true when per-user transfer cap exceeded")
+	}
+
+	// Clear the cap; get_note should now succeed.
+	resp = doIntegrationRequest(t, h, admin.UserID, "tools/call", map[string]any{
+		"name": "update_user",
+		"arguments": map[string]any{
+			"user_id":            user.UserID,
+			"transfer_cap_bytes": float64(-1),
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("update_user (clear transfer cap): %+v", resp.Error)
+	}
+
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "get_note",
+		"arguments": map[string]any{"note_id": noteID},
+	})
+	if resp.Error != nil {
+		t.Fatalf("get_note after cap cleared: %+v", resp.Error)
+	}
+	var result2 struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &result2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result2.IsError {
+		t.Errorf("expected success after cap cleared, got: %s", firstContentText(t, resp.Result))
+	}
 }
 
 // ---- test helpers ----

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -43,7 +43,7 @@ type rpcResp struct {
 // auth.WithUserContext, bypassing auth.Middleware entirely. Safe for tests
 // that don't need DB or S3.
 func newUnitHandler(user *models.User) http.Handler {
-	h := handlers.New(nil, nil)
+	h := handlers.New(nil, nil, handlers.Config{})
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -496,7 +496,7 @@ func saveIntegrationUser(t *testing.T, dbClient *db.Client, status models.UserSt
 // real Bearer tokens are validated against DynamoDB.
 func newIntegrationHandler(t *testing.T, dbClient *db.Client, storeClient *store.Client) http.Handler {
 	t.Helper()
-	h := handlers.New(dbClient, storeClient)
+	h := handlers.New(dbClient, storeClient, handlers.Config{})
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 	cfg := auth.Config{
@@ -842,6 +842,162 @@ func TestIntegrationUserCannotCallAdminTool(t *testing.T) {
 	}
 	if resp.Error.Code != -32601 {
 		t.Errorf("code: got %d want -32601", resp.Error.Code)
+	}
+}
+
+func newIntegrationHandlerWithConfig(t *testing.T, dbClient *db.Client, storeClient *store.Client, cfg handlers.Config) http.Handler {
+	t.Helper()
+	h := handlers.New(dbClient, storeClient, cfg)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	authCfg := auth.Config{
+		ClientID:     "x",
+		ClientSecret: "x",
+		RedirectURL:  "https://example.com/auth/callback",
+		TokenSecret:  testSecret,
+	}
+	return auth.Middleware(authCfg, dbClient, mux)
+}
+
+func TestIntegrationStorageCapEnforced(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	// Cap is 10 bytes — any real content will exceed it.
+	h := newIntegrationHandlerWithConfig(t, dbClient, storeClient, handlers.Config{
+		DefaultStorageCap:  10,
+		DefaultTransferCap: handlers.DefaultTransferCapBytes,
+	})
+
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Cap Test",
+			"content": "this content is definitely more than 10 bytes",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %+v", resp.Error)
+	}
+	var result struct {
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true when storage cap exceeded")
+	}
+	text := firstContentText(t, resp.Result)
+	if text == "" {
+		t.Error("expected error message in content")
+	}
+}
+
+func TestIntegrationTransferCapEnforced(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	// Transfer cap is 1 byte — any real get response will exceed it.
+	h := newIntegrationHandlerWithConfig(t, dbClient, storeClient, handlers.Config{
+		DefaultStorageCap:  handlers.DefaultStorageCapBytes,
+		DefaultTransferCap: 1,
+	})
+
+	// Create a note (doesn't hit transfer cap).
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Transfer Cap Test",
+			"content": "hello",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_note: %+v", resp.Error)
+	}
+	noteID := extractField(t, resp.Result, "id")
+	t.Cleanup(func() {
+		doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+			"name":      "delete_note",
+			"arguments": map[string]any{"note_id": noteID},
+		})
+	})
+
+	// get_note must be blocked by the transfer cap.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "get_note",
+		"arguments": map[string]any{"note_id": noteID},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %+v", resp.Error)
+	}
+	var result struct {
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true when transfer cap exceeded")
+	}
+}
+
+func TestIntegrationUsageVisibleInListUsers(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	admin := saveIntegrationUser(t, dbClient, models.StatusAdmin)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	// Save a note to accumulate some storage usage.
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Usage Test",
+			"content": "some content for storage tracking",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_note: %+v", resp.Error)
+	}
+	noteID := extractField(t, resp.Result, "id")
+	t.Cleanup(func() {
+		doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+			"name":      "delete_note",
+			"arguments": map[string]any{"note_id": noteID},
+		})
+	})
+
+	// Admin lists users — find our user and check usage fields are present.
+	resp = doIntegrationRequest(t, h, admin.UserID, "tools/call", map[string]any{
+		"name":      "list_users",
+		"arguments": map[string]any{},
+	})
+	if resp.Error != nil {
+		t.Fatalf("list_users: %+v", resp.Error)
+	}
+
+	text := firstContentText(t, resp.Result)
+	var users []map[string]any
+	if err := json.Unmarshal([]byte(text), &users); err != nil {
+		t.Fatalf("unmarshal users: %v", err)
+	}
+
+	found := false
+	for _, u := range users {
+		if u["user_id"] == user.UserID {
+			found = true
+			if _, ok := u["storage_used_pct"]; !ok {
+				t.Error("storage_used_pct missing from list_users response")
+			}
+			if _, ok := u["transfer_used_pct"]; !ok {
+				t.Error("transfer_used_pct missing from list_users response")
+			}
+			// Storage should be > 0 after saving a note.
+			if pct, ok := u["storage_used_pct"].(float64); !ok || pct < 0 {
+				t.Errorf("storage_used_pct: unexpected value %v", u["storage_used_pct"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("user %s not found in list_users response", user.UserID)
 	}
 }
 

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -1168,6 +1168,23 @@ func TestIntegrationPerUserTransferCapOverride(t *testing.T) {
 	}
 }
 
+func TestUpdateUserNoFields(t *testing.T) {
+	// update_user with only user_id and no other fields should return -32602.
+	user := &models.User{UserID: "u1", Status: models.StatusAdmin}
+	h := newUnitHandler(user)
+
+	resp := doMCPRequest(t, h, "tools/call", map[string]any{
+		"name":      "update_user",
+		"arguments": map[string]any{"user_id": "u2"},
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error when no fields provided to update_user")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("code: got %d want -32602 (invalid params)", resp.Error.Code)
+	}
+}
+
 // ---- test helpers ----
 
 type toolEntry struct {

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -884,6 +884,34 @@ func TestIntegrationStorageCapEnforced(t *testing.T) {
 	}
 }
 
+func TestIntegrationFileStorageCapEnforced(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	// Cap is 10 bytes — any real file content will exceed it.
+	h := newIntegrationHandlerWithConfig(t, dbClient, storeClient, handlers.Config{
+		DefaultStorageCap:  10,
+		DefaultTransferCap: handlers.DefaultTransferCapBytes,
+	})
+
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_file",
+		"arguments": map[string]any{
+			"path":    "test/cap-test.txt",
+			"content": "this content is definitely more than 10 bytes",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %+v", resp.Error)
+	}
+	var result struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true when file storage cap exceeded")
+	}
+}
+
 func TestIntegrationTransferCapEnforced(t *testing.T) {
 	dbClient, storeClient := newTestClients(t)
 	user := saveIntegrationUser(t, dbClient, models.StatusUser)

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -492,20 +492,11 @@ func saveIntegrationUser(t *testing.T, dbClient *db.Client, status models.UserSt
 	return u
 }
 
-// newIntegrationHandler wraps the real handler with auth.Middleware so that
-// real Bearer tokens are validated against DynamoDB.
+// newIntegrationHandler wraps the real handler with auth.Middleware using
+// server-default caps (1 GB each). Delegates to newIntegrationHandlerWithConfig.
 func newIntegrationHandler(t *testing.T, dbClient *db.Client, storeClient *store.Client) http.Handler {
 	t.Helper()
-	h := handlers.New(dbClient, storeClient, handlers.Config{})
-	mux := http.NewServeMux()
-	h.RegisterRoutes(mux)
-	cfg := auth.Config{
-		ClientID:     "x",
-		ClientSecret: "x",
-		RedirectURL:  "https://example.com/auth/callback",
-		TokenSecret:  testSecret,
-	}
-	return auth.Middleware(cfg, dbClient, mux)
+	return newIntegrationHandlerWithConfig(t, dbClient, storeClient, handlers.Config{})
 }
 
 func doIntegrationRequest(t *testing.T, h http.Handler, userID string, method string, params any) *rpcResp {
@@ -1085,6 +1076,62 @@ func TestIntegrationPerUserCapOverride(t *testing.T) {
 			"arguments": map[string]any{"note_id": noteID},
 		})
 	})
+}
+
+func TestIntegrationStorageCapEnforcedOnUpdate(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	// Cap is 50 bytes — enough for the initial save but not the larger update.
+	h := newIntegrationHandlerWithConfig(t, dbClient, storeClient, handlers.Config{
+		DefaultStorageCap:  50,
+		DefaultTransferCap: handlers.DefaultTransferCapBytes,
+	})
+
+	// Create a small note that fits under the cap.
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Cap Update Test",
+			"content": "small",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_note (create): %+v", resp.Error)
+	}
+	var createResult struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &createResult); err != nil {
+		t.Fatalf("unmarshal create: %v", err)
+	}
+	if createResult.IsError {
+		t.Fatalf("save_note (create) unexpectedly blocked: %s", firstContentText(t, resp.Result))
+	}
+	noteID := extractField(t, resp.Result, "id")
+	t.Cleanup(func() {
+		doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+			"name":      "delete_note",
+			"arguments": map[string]any{"note_id": noteID},
+		})
+	})
+
+	// Update with content large enough to push the total over the 50-byte cap.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"note_id": noteID,
+			"title":   "Cap Update Test",
+			"content": "this updated content is definitely more than fifty bytes total",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error on update: %+v", resp.Error)
+	}
+	var updateResult struct{ IsError bool }
+	if err := json.Unmarshal(resp.Result, &updateResult); err != nil {
+		t.Fatalf("unmarshal update: %v", err)
+	}
+	if !updateResult.IsError {
+		t.Error("expected isError=true when update pushes note past storage cap")
+	}
 }
 
 func TestIntegrationPerUserTransferCapOverride(t *testing.T) {

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -912,6 +912,70 @@ func TestIntegrationFileStorageCapEnforced(t *testing.T) {
 	}
 }
 
+func TestIntegrationStorageDecrementedOnDelete(t *testing.T) {
+	dbClient, storeClient := newTestClients(t)
+	admin := saveIntegrationUser(t, dbClient, models.StatusAdmin)
+	user := saveIntegrationUser(t, dbClient, models.StatusUser)
+	h := newIntegrationHandler(t, dbClient, storeClient)
+
+	// Save a note to establish some storage usage.
+	resp := doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name": "save_note",
+		"arguments": map[string]any{
+			"title":   "Delete Decrement Test",
+			"content": "some content",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("save_note: %+v", resp.Error)
+	}
+	noteID := extractField(t, resp.Result, "id")
+
+	// Capture storage usage after save via list_users.
+	usageBefore := getStorageUsedPct(t, h, admin.UserID, user.UserID)
+
+	// Delete the note.
+	resp = doIntegrationRequest(t, h, user.UserID, "tools/call", map[string]any{
+		"name":      "delete_note",
+		"arguments": map[string]any{"note_id": noteID},
+	})
+	if resp.Error != nil {
+		t.Fatalf("delete_note: %+v", resp.Error)
+	}
+
+	// Storage usage should be lower (or zero) after delete.
+	usageAfter := getStorageUsedPct(t, h, admin.UserID, user.UserID)
+	if usageAfter >= usageBefore {
+		t.Errorf("storage_used_pct: want < %d after delete, got %d", usageBefore, usageAfter)
+	}
+}
+
+// getStorageUsedPct returns the storage_used_pct for targetUserID from list_users.
+func getStorageUsedPct(t *testing.T, h http.Handler, adminUserID, targetUserID string) int {
+	t.Helper()
+	resp := doIntegrationRequest(t, h, adminUserID, "tools/call", map[string]any{
+		"name":      "list_users",
+		"arguments": map[string]any{},
+	})
+	if resp.Error != nil {
+		t.Fatalf("list_users: %+v", resp.Error)
+	}
+	text := firstContentText(t, resp.Result)
+	var users []map[string]any
+	if err := json.Unmarshal([]byte(text), &users); err != nil {
+		t.Fatalf("unmarshal users: %v", err)
+	}
+	for _, u := range users {
+		if u["user_id"] == targetUserID {
+			if pct, ok := u["storage_used_pct"].(float64); ok {
+				return int(pct)
+			}
+		}
+	}
+	t.Fatalf("user %s not found in list_users", targetUserID)
+	return 0
+}
+
 func TestIntegrationTransferCapEnforced(t *testing.T) {
 	dbClient, storeClient := newTestClients(t)
 	user := saveIntegrationUser(t, dbClient, models.StatusUser)

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -56,29 +56,29 @@ func New(dbClient *db.Client, storeClient *store.Client, cfg Config) *Handler {
 }
 
 // effectiveStorageCap returns the storage cap in bytes for a user, falling back
-// to the server default. A cap of 0 (set explicitly via update_user) blocks all
-// writes — this is intentional. A negative value is clamped to 1 to avoid
-// arithmetic confusion; negative caps should never be stored but guard anyway.
+// to the server default. A per-user cap of 0 blocks all writes — intentional.
+// Negative values can't be stored (handleUpdateUser rejects them via the >= 0
+// guard), but clamp to 0 defensively so the > comparison stays correct.
 func (h *Handler) effectiveStorageCap(u *models.User) int64 {
 	cap := h.cfg.DefaultStorageCap
 	if u.StorageCapBytes != nil {
 		cap = *u.StorageCapBytes
 	}
 	if cap < 0 {
-		return 1
+		return 0
 	}
 	return cap
 }
 
 // effectiveTransferCap returns the monthly transfer cap in bytes for a user,
-// falling back to the server default. Same zero/negative semantics as effectiveStorageCap.
+// falling back to the server default. Same semantics as effectiveStorageCap.
 func (h *Handler) effectiveTransferCap(u *models.User) int64 {
 	cap := h.cfg.DefaultTransferCap
 	if u.TransferCapBytes != nil {
 		cap = *u.TransferCapBytes
 	}
 	if cap < 0 {
-		return 1
+		return 0
 	}
 	return cap
 }
@@ -88,9 +88,15 @@ func currentMonth() string {
 	return time.Now().UTC().Format("2006-01")
 }
 
-// transferTTL returns a Unix timestamp 60 days from now, used as TTL on transfer records.
+// transferRecordTTL is how long monthly transfer records are retained. 60 days
+// ensures the previous month is always available for debugging while old records
+// auto-delete without a cron job.
+const transferRecordTTL = 60 * 24 * time.Hour
+
+// transferTTL returns a Unix timestamp transferRecordTTL from now, for use as
+// the DynamoDB TTL attribute on TRANSFER#YYYY-MM items.
 func transferTTL() int64 {
-	return time.Now().UTC().Add(60 * 24 * time.Hour).Unix()
+	return time.Now().UTC().Add(transferRecordTTL).Unix()
 }
 
 // checkTransferCap reads the current month's transfer usage for the user and

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -397,27 +397,25 @@ func newID() string {
 	return hex.EncodeToString(b)
 }
 
-// int64ArgOpt reads an optional numeric argument as int64, returning (0, false)
-// if absent. Returns (value, true) if present; caller should pass -1 to mean
-// "clear the cap" so that 0 is distinguishable from "not provided".
-// Logs a warning and returns (0, false) if the field is present but not a
-// recognized numeric type — treats it the same as absent rather than erroring,
-// matching the soft-validation style of other optional args.
-func int64ArgOpt(args map[string]any, key string) (int64, bool) {
+// int64ArgOpt reads an optional numeric argument as int64.
+// Returns (value, true, nil) if present and valid.
+// Returns (0, false, nil) if absent.
+// Returns (0, true, err) if present but not a recognized numeric type — callers
+// should surface this as an invalid-params error for security-relevant fields.
+func int64ArgOpt(args map[string]any, key string) (int64, bool, error) {
 	v, ok := args[key]
 	if !ok {
-		return 0, false
+		return 0, false, nil
 	}
 	switch n := v.(type) {
 	case float64:
-		return int64(n), true
+		return int64(n), true, nil
 	case int64:
-		return n, true
+		return n, true, nil
 	case int:
-		return int64(n), true
+		return int64(n), true, nil
 	default:
-		log.Printf("mcp: arg %q: unexpected type %T, ignoring", key, v)
-		return 0, false
+		return 0, true, fmt.Errorf("argument %q must be a number, got %T", key, v)
 	}
 }
 

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -99,16 +99,16 @@ func transferTTL() int64 {
 	return time.Now().UTC().Add(transferRecordTTL).Unix()
 }
 
-// checkTransferCap reads the current month's transfer usage for the user and
-// returns it. The caller fetches S3 content first, serializes the response,
-// then calls this to decide whether to block (post-fetch check). The check is
-// post-fetch by design: response size can only be known after serialization.
+// readTransferUsed returns the current month's transfer byte total for the user.
+// Callers fetch S3 content first, serialize the response, then call this and
+// compare the result against effectiveTransferCap to decide whether to block
+// (post-fetch by design: response size is only known after serialization).
 //
 // The read-check-increment is not atomic: two concurrent requests can both pass
-// the check and both record transfer, potentially exceeding the cap by up to one
+// the cap check and both record transfer, exceeding the cap by up to one
 // response's worth of bytes. This is accepted as soft enforcement — the cap is
 // an abuse guard, not a hard billing limit.
-func (h *Handler) checkTransferCap(ctx context.Context, user *models.User) (int64, *rpcError) {
+func (h *Handler) readTransferUsed(ctx context.Context, user *models.User) (int64, *rpcError) {
 	used, err := h.db.GetTransferUsed(ctx, user.UserID, currentMonth())
 	if err != nil {
 		log.Printf("mcp: get transfer used for %s: %v", user.UserID, err)

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -22,16 +23,74 @@ const (
 	serverVersion      = "0.1.0"
 )
 
+const (
+	// DefaultStorageCapBytes is 1 GB — overridden by DEFAULT_STORAGE_CAP_BYTES env var.
+	DefaultStorageCapBytes int64 = 1 << 30
+	// DefaultTransferCapBytes is 1 GB/month — overridden by DEFAULT_TRANSFER_CAP_BYTES env var.
+	DefaultTransferCapBytes int64 = 1 << 30
+)
+
+// Config holds handler-level configuration (currently just default caps).
+type Config struct {
+	DefaultStorageCap  int64
+	DefaultTransferCap int64
+}
+
 // Handler is the MCP protocol handler.
 type Handler struct {
 	db    *db.Client
 	store *store.Client
+	cfg   Config
 }
 
 // New creates an MCP Handler. Passing nil for dbClient or storeClient is safe
 // only for unit tests that exercise code paths not reaching the DB or store.
-func New(dbClient *db.Client, storeClient *store.Client) *Handler {
-	return &Handler{db: dbClient, store: storeClient}
+func New(dbClient *db.Client, storeClient *store.Client, cfg Config) *Handler {
+	if cfg.DefaultStorageCap == 0 {
+		cfg.DefaultStorageCap = DefaultStorageCapBytes
+	}
+	if cfg.DefaultTransferCap == 0 {
+		cfg.DefaultTransferCap = DefaultTransferCapBytes
+	}
+	return &Handler{db: dbClient, store: storeClient, cfg: cfg}
+}
+
+// effectiveStorageCap returns the cap in bytes for a user, falling back to the default.
+func (h *Handler) effectiveStorageCap(u *models.User) int64 {
+	if u.StorageCapBytes != nil {
+		return *u.StorageCapBytes
+	}
+	return h.cfg.DefaultStorageCap
+}
+
+// effectiveTransferCap returns the monthly transfer cap in bytes, falling back to the default.
+func (h *Handler) effectiveTransferCap(u *models.User) int64 {
+	if u.TransferCapBytes != nil {
+		return *u.TransferCapBytes
+	}
+	return h.cfg.DefaultTransferCap
+}
+
+// currentMonth returns the current UTC month in YYYY-MM format for transfer records.
+func currentMonth() string {
+	return time.Now().UTC().Format("2006-01")
+}
+
+// transferTTL returns a Unix timestamp 60 days from now, used as TTL on transfer records.
+func transferTTL() int64 {
+	return time.Now().UTC().Add(60 * 24 * time.Hour).Unix()
+}
+
+// checkTransferCap reads the current month's transfer usage for the user and
+// returns it. Returns an rpcError if the DB read fails (not if over cap — the
+// caller decides whether to block based on the response size).
+func (h *Handler) checkTransferCap(ctx context.Context, user *models.User) (int64, *rpcError) {
+	used, err := h.db.GetTransferUsed(ctx, user.UserID, currentMonth())
+	if err != nil {
+		log.Printf("mcp: get transfer used for %s: %v", user.UserID, err)
+		return 0, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+	return used, nil
 }
 
 // RegisterRoutes wires the MCP endpoint onto the given mux.
@@ -313,6 +372,25 @@ func newID() string {
 	return hex.EncodeToString(b)
 }
 
+// int64ArgOpt reads an optional numeric argument as int64, returning (0, false)
+// if absent. Returns (value, true) if present; caller should pass -1 to mean
+// "clear the cap" so that 0 is distinguishable from "not provided".
+func int64ArgOpt(args map[string]any, key string) (int64, bool) {
+	v, ok := args[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	}
+	return 0, false
+}
+
 // versionArg reads the optional "version" argument as int.
 func versionArg(args map[string]any) int {
 	v, ok := args["version"]
@@ -335,6 +413,12 @@ func dbErrResult(err error) (*toolsCallResult, *rpcError) {
 	}
 	if errors.Is(err, db.ErrVersionConflict) {
 		return errorResult("version conflict: reload and retry")
+	}
+	if errors.Is(err, db.ErrStorageCap) {
+		return errorResult("Storage cap reached. Contact your administrator to adjust your cap.")
+	}
+	if errors.Is(err, db.ErrTransferCap) {
+		return errorResult("Monthly transfer cap reached. Contact your administrator to adjust your cap.")
 	}
 	log.Printf("mcp: db error: %v", err)
 	return nil, &rpcError{Code: codeInternalError, Message: "internal error"}

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -55,20 +55,32 @@ func New(dbClient *db.Client, storeClient *store.Client, cfg Config) *Handler {
 	return &Handler{db: dbClient, store: storeClient, cfg: cfg}
 }
 
-// effectiveStorageCap returns the cap in bytes for a user, falling back to the default.
+// effectiveStorageCap returns the storage cap in bytes for a user, falling back
+// to the server default. A cap of 0 (set explicitly via update_user) blocks all
+// writes — this is intentional. A negative value is clamped to 1 to avoid
+// arithmetic confusion; negative caps should never be stored but guard anyway.
 func (h *Handler) effectiveStorageCap(u *models.User) int64 {
+	cap := h.cfg.DefaultStorageCap
 	if u.StorageCapBytes != nil {
-		return *u.StorageCapBytes
+		cap = *u.StorageCapBytes
 	}
-	return h.cfg.DefaultStorageCap
+	if cap < 0 {
+		return 1
+	}
+	return cap
 }
 
-// effectiveTransferCap returns the monthly transfer cap in bytes, falling back to the default.
+// effectiveTransferCap returns the monthly transfer cap in bytes for a user,
+// falling back to the server default. Same zero/negative semantics as effectiveStorageCap.
 func (h *Handler) effectiveTransferCap(u *models.User) int64 {
+	cap := h.cfg.DefaultTransferCap
 	if u.TransferCapBytes != nil {
-		return *u.TransferCapBytes
+		cap = *u.TransferCapBytes
 	}
-	return h.cfg.DefaultTransferCap
+	if cap < 0 {
+		return 1
+	}
+	return cap
 }
 
 // currentMonth returns the current UTC month in YYYY-MM format for transfer records.

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -57,8 +57,9 @@ func New(dbClient *db.Client, storeClient *store.Client, cfg Config) *Handler {
 
 // effectiveStorageCap returns the storage cap in bytes for a user, falling back
 // to the server default. A per-user cap of 0 blocks all writes — intentional.
-// Negative values can't be stored (handleUpdateUser rejects them via the >= 0
-// guard), but clamp to 0 defensively so the > comparison stays correct.
+// Negative values can't be stored: handleUpdateUser passes nil to UpdateStorageCap
+// for values < 0 (clearing the override), so the DB attribute is always >= 0 or
+// absent. The clamp to 0 is purely defensive.
 func (h *Handler) effectiveStorageCap(u *models.User) int64 {
 	capBytes := h.cfg.DefaultStorageCap
 	if u.StorageCapBytes != nil {

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -84,6 +84,11 @@ func transferTTL() int64 {
 // checkTransferCap reads the current month's transfer usage for the user and
 // returns it. Returns an rpcError if the DB read fails (not if over cap — the
 // caller decides whether to block based on the response size).
+//
+// The read-check-increment is not atomic: two concurrent requests can both pass
+// the check and both record transfer, potentially exceeding the cap by up to one
+// response's worth of bytes. This is accepted as soft enforcement — the cap is
+// an abuse guard, not a hard billing limit.
 func (h *Handler) checkTransferCap(ctx context.Context, user *models.User) (int64, *rpcError) {
 	used, err := h.db.GetTransferUsed(ctx, user.UserID, currentMonth())
 	if err != nil {

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -302,6 +302,8 @@ func errorResult(text string) (*toolsCallResult, *rpcError) {
 }
 
 // jsonResult serialises v as pretty JSON inside an MCP content block.
+// Always returns exactly one content item — callers that index Content[0]
+// directly (e.g. to measure response size) are safe to do so.
 func jsonResult(v any) (*toolsCallResult, *rpcError) {
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -399,6 +399,9 @@ func newID() string {
 // int64ArgOpt reads an optional numeric argument as int64, returning (0, false)
 // if absent. Returns (value, true) if present; caller should pass -1 to mean
 // "clear the cap" so that 0 is distinguishable from "not provided".
+// Logs a warning and returns (0, false) if the field is present but not a
+// recognized numeric type — treats it the same as absent rather than erroring,
+// matching the soft-validation style of other optional args.
 func int64ArgOpt(args map[string]any, key string) (int64, bool) {
 	v, ok := args[key]
 	if !ok {
@@ -411,8 +414,10 @@ func int64ArgOpt(args map[string]any, key string) (int64, bool) {
 		return n, true
 	case int:
 		return int64(n), true
+	default:
+		log.Printf("mcp: arg %q: unexpected type %T, ignoring", key, v)
+		return 0, false
 	}
-	return 0, false
 }
 
 // versionArg reads the optional "version" argument as int.

--- a/internal/handlers/mcp.go
+++ b/internal/handlers/mcp.go
@@ -60,27 +60,27 @@ func New(dbClient *db.Client, storeClient *store.Client, cfg Config) *Handler {
 // Negative values can't be stored (handleUpdateUser rejects them via the >= 0
 // guard), but clamp to 0 defensively so the > comparison stays correct.
 func (h *Handler) effectiveStorageCap(u *models.User) int64 {
-	cap := h.cfg.DefaultStorageCap
+	capBytes := h.cfg.DefaultStorageCap
 	if u.StorageCapBytes != nil {
-		cap = *u.StorageCapBytes
+		capBytes = *u.StorageCapBytes
 	}
-	if cap < 0 {
+	if capBytes < 0 {
 		return 0
 	}
-	return cap
+	return capBytes
 }
 
 // effectiveTransferCap returns the monthly transfer cap in bytes for a user,
 // falling back to the server default. Same semantics as effectiveStorageCap.
 func (h *Handler) effectiveTransferCap(u *models.User) int64 {
-	cap := h.cfg.DefaultTransferCap
+	capBytes := h.cfg.DefaultTransferCap
 	if u.TransferCapBytes != nil {
-		cap = *u.TransferCapBytes
+		capBytes = *u.TransferCapBytes
 	}
-	if cap < 0 {
+	if capBytes < 0 {
 		return 0
 	}
-	return cap
+	return capBytes
 }
 
 // currentMonth returns the current UTC month in YYYY-MM format for transfer records.
@@ -100,8 +100,9 @@ func transferTTL() int64 {
 }
 
 // checkTransferCap reads the current month's transfer usage for the user and
-// returns it. Returns an rpcError if the DB read fails (not if over cap — the
-// caller decides whether to block based on the response size).
+// returns it. The caller fetches S3 content first, serializes the response,
+// then calls this to decide whether to block (post-fetch check). The check is
+// post-fetch by design: response size can only be known after serialization.
 //
 // The read-check-increment is not atomic: two concurrent requests can both pass
 // the check and both record transfer, potentially exceeding the cap by up to one

--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -343,10 +343,10 @@ func (h *Handler) adminTools() []registeredTool {
 		{
 			def: toolDef{
 				Name:        "update_user",
-				Description: "Update a user's status and optionally their storage or transfer cap. Pass -1 for a cap to clear the per-user override and restore the server default.",
+				Description: "Update a user's status and/or caps. All fields except user_id are optional; at least one must be provided. Pass -1 for a cap to restore the server default.",
 				InputSchema: schema{
 					Type:     "object",
-					Required: []string{"user_id", "status"},
+					Required: []string{"user_id"},
 					Properties: map[string]property{
 						"user_id":            {Type: "string", Description: "User ID."},
 						"status":             {Type: "string", Description: "New status.", Enum: []string{"pending", "user", "admin", "banned"}},

--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -343,13 +343,15 @@ func (h *Handler) adminTools() []registeredTool {
 		{
 			def: toolDef{
 				Name:        "update_user",
-				Description: "Update a user's status.",
+				Description: "Update a user's status and optionally their storage or transfer cap. Pass -1 for a cap to clear the per-user override and restore the server default.",
 				InputSchema: schema{
 					Type:     "object",
 					Required: []string{"user_id", "status"},
 					Properties: map[string]property{
-						"user_id": {Type: "string", Description: "User ID."},
-						"status":  {Type: "string", Description: "New status.", Enum: []string{"pending", "user", "admin", "banned"}},
+						"user_id":            {Type: "string", Description: "User ID."},
+						"status":             {Type: "string", Description: "New status.", Enum: []string{"pending", "user", "admin", "banned"}},
+						"storage_cap_bytes":  {Type: "number", Description: "Per-user storage cap in bytes. Omit to leave unchanged; pass -1 to restore server default."},
+						"transfer_cap_bytes": {Type: "number", Description: "Per-user monthly transfer cap in bytes. Omit to leave unchanged; pass -1 to restore server default."},
 					},
 				},
 			},

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -9,6 +9,13 @@ import (
 	"github.com/pwntato/notoriousmcp/internal/models"
 )
 
+// userWithUsage wraps a User and adds computed usage percentage fields for admins.
+type userWithUsage struct {
+	models.User
+	StorageUsedPct  int `json:"storage_used_pct"`
+	TransferUsedPct int `json:"transfer_used_pct"`
+}
+
 func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*toolsCallResult, *rpcError) {
 	statusStr := strArgOpt(args, "status")
 	var statusFilter *models.UserStatus
@@ -25,7 +32,31 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 	if err != nil {
 		return dbErrResult(err)
 	}
-	return jsonResult(users)
+
+	month := currentMonth()
+	out := make([]userWithUsage, 0, len(users))
+	for _, u := range users {
+		transferUsed, err := h.db.GetTransferUsed(ctx, u.UserID, month)
+		if err != nil {
+			log.Printf("admin: list users: get transfer for %s: %v", u.UserID, err)
+		}
+		storageCap := h.effectiveStorageCap(&u)
+		transferCap := h.effectiveTransferCap(&u)
+		storagePct := 0
+		if storageCap > 0 {
+			storagePct = int(u.StorageUsedBytes * 100 / storageCap)
+		}
+		transferPct := 0
+		if transferCap > 0 {
+			transferPct = int(transferUsed * 100 / transferCap)
+		}
+		out = append(out, userWithUsage{
+			User:            u,
+			StorageUsedPct:  storagePct,
+			TransferUsedPct: transferPct,
+		})
+	}
+	return jsonResult(out)
 }
 
 func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
@@ -55,6 +86,25 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 		}
 		return dbErrResult(err)
 	}
+
+	// Optional cap overrides. Both are nullable: pass -1 to clear, omit to leave unchanged.
+	storageCap, hasStorage := int64ArgOpt(args, "storage_cap_bytes")
+	transferCap, hasTransfer := int64ArgOpt(args, "transfer_cap_bytes")
+	if hasStorage || hasTransfer {
+		var scPtr, tcPtr *int64
+		if hasStorage && storageCap >= 0 {
+			scPtr = &storageCap
+		}
+		if hasTransfer && transferCap >= 0 {
+			tcPtr = &transferCap
+		}
+		if err := h.db.UpdateUserCaps(ctx, userID, scPtr, tcPtr); err != nil {
+			if !errors.Is(err, db.ErrNotFound) {
+				log.Printf("admin: update caps for %s: %v", userID, err)
+			}
+		}
+	}
+
 	log.Printf("admin: user %s status set to %s", userID, status)
 	return textResult("user updated")
 }

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"sync"
 
 	"github.com/pwntato/notoriousmcp/internal/db"
 	"github.com/pwntato/notoriousmcp/internal/models"
@@ -34,31 +35,41 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 	}
 
 	month := currentMonth()
-	out := make([]userWithUsage, 0, len(users))
-	// TODO: replace with BatchGetItem if user count grows large.
-	for _, u := range users {
-		transferUsed, err := h.db.GetTransferUsed(ctx, u.UserID, month)
-		if err != nil {
-			log.Printf("admin: list users: get transfer for %s: %v", u.UserID, err)
-		}
-		storageCap := h.effectiveStorageCap(&u)
-		transferCap := h.effectiveTransferCap(&u)
-		storagePct := 0
-		if storageCap > 0 && u.StorageUsedBytes > 0 {
-			// Round up to 1 so any non-zero usage shows as at least 1% rather
-			// than silently appearing as 0 for small values.
-			storagePct = max(1, int(float64(u.StorageUsedBytes)*100/float64(storageCap)))
-		}
-		transferPct := 0
-		if transferCap > 0 && transferUsed > 0 {
-			transferPct = max(1, int(float64(transferUsed)*100/float64(transferCap)))
-		}
-		out = append(out, userWithUsage{
-			User:            u,
-			StorageUsedPct:  storagePct,
-			TransferUsedPct: transferPct,
-		})
+	out := make([]userWithUsage, len(users))
+
+	// Fetch per-user transfer totals concurrently — one GetItem per user would
+	// be slow in serial for large user lists.
+	// TODO: replace with BatchGetItem once user counts grow enough to matter.
+	var wg sync.WaitGroup
+	for i := range users {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			u := &users[i]
+			transferUsed, err := h.db.GetTransferUsed(ctx, u.UserID, month)
+			if err != nil {
+				log.Printf("admin: list users: get transfer for %s: %v", u.UserID, err)
+			}
+			storageCap := h.effectiveStorageCap(u)
+			transferCap := h.effectiveTransferCap(u)
+			storagePct := 0
+			if storageCap > 0 && u.StorageUsedBytes > 0 {
+				// Round up to 1 so any non-zero usage shows as at least 1%.
+				// Capped at 100 — over-quota is already blocked at write time.
+				storagePct = min(100, max(1, int(float64(u.StorageUsedBytes)*100/float64(storageCap))))
+			}
+			transferPct := 0
+			if transferCap > 0 && transferUsed > 0 {
+				transferPct = min(100, max(1, int(float64(transferUsed)*100/float64(transferCap))))
+			}
+			out[i] = userWithUsage{
+				User:            *u,
+				StorageUsedPct:  storagePct,
+				TransferUsedPct: transferPct,
+			}
+		}(i)
 	}
+	wg.Wait()
 	return jsonResult(out)
 }
 

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -10,7 +11,9 @@ import (
 	"github.com/pwntato/notoriousmcp/internal/models"
 )
 
-// userWithUsage wraps a User and adds computed usage percentage fields for admins.
+// userWithUsage wraps a User with computed usage percentages for the admin
+// list_users response. This is the only path where User is serialized to JSON;
+// both list_users and update_user are admin-only tools.
 type userWithUsage struct {
 	models.User
 	StorageUsedPct  int `json:"storage_used_pct"`
@@ -36,6 +39,7 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 
 	month := currentMonth()
 	out := make([]userWithUsage, len(users))
+	errc := make(chan error, len(users))
 
 	// Fetch per-user transfer totals concurrently — one GetItem per user would
 	// be slow in serial for large user lists.
@@ -46,9 +50,10 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 		go func(i int) {
 			defer wg.Done()
 			u := &users[i]
-			transferUsed, err := h.db.GetTransferUsed(ctx, u.UserID, month)
+			transferUsedBefore, err := h.db.GetTransferUsed(ctx, u.UserID, month)
 			if err != nil {
-				log.Printf("admin: list users: get transfer for %s: %v", u.UserID, err)
+				errc <- fmt.Errorf("get transfer for %s: %w", u.UserID, err)
+				return
 			}
 			storageCap := h.effectiveStorageCap(u)
 			transferCap := h.effectiveTransferCap(u)
@@ -59,8 +64,8 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 				storagePct = min(100, max(1, int(float64(u.StorageUsedBytes)*100/float64(storageCap))))
 			}
 			transferPct := 0
-			if transferCap > 0 && transferUsed > 0 {
-				transferPct = min(100, max(1, int(float64(transferUsed)*100/float64(transferCap))))
+			if transferCap > 0 && transferUsedBefore > 0 {
+				transferPct = min(100, max(1, int(float64(transferUsedBefore)*100/float64(transferCap))))
 			}
 			out[i] = userWithUsage{
 				User:            *u,
@@ -70,6 +75,11 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 		}(i)
 	}
 	wg.Wait()
+	close(errc)
+	for err := range errc {
+		log.Printf("admin: list users: %v", err)
+		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
 	return jsonResult(out)
 }
 
@@ -79,8 +89,15 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
 
-	// status is optional — omit when only updating caps.
+	// Validate that at least one field is being changed before touching the DB.
 	statusStr := strArgOpt(args, "status")
+	_, hasStorage := int64ArgOpt(args, "storage_cap_bytes")
+	_, hasTransfer := int64ArgOpt(args, "transfer_cap_bytes")
+	if statusStr == "" && !hasStorage && !hasTransfer {
+		return nil, &rpcError{Code: codeInvalidParams, Message: "at least one of status, storage_cap_bytes, or transfer_cap_bytes must be provided"}
+	}
+
+	// status is optional — omit when only updating caps.
 	if statusStr != "" {
 		status := models.UserStatus(statusStr)
 		switch status {
@@ -104,9 +121,7 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 
 	// Optional cap overrides. Each field is independent: omit to leave unchanged,
 	// pass -1 to clear the per-user override and restore the server default.
-	anyCap := false
-	if storageCap, hasStorage := int64ArgOpt(args, "storage_cap_bytes"); hasStorage {
-		anyCap = true
+	if storageCap, ok := int64ArgOpt(args, "storage_cap_bytes"); ok {
 		var capPtr *int64
 		if storageCap >= 0 {
 			capPtr = &storageCap
@@ -119,8 +134,7 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 			return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 		}
 	}
-	if transferCap, hasTransfer := int64ArgOpt(args, "transfer_cap_bytes"); hasTransfer {
-		anyCap = true
+	if transferCap, ok := int64ArgOpt(args, "transfer_cap_bytes"); ok {
 		var capPtr *int64
 		if transferCap >= 0 {
 			capPtr = &transferCap
@@ -132,10 +146,6 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 			log.Printf("admin: update transfer cap for %s: %v", userID, err)
 			return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 		}
-	}
-
-	if statusStr == "" && !anyCap {
-		return nil, &rpcError{Code: codeInvalidParams, Message: "at least one of status, storage_cap_bytes, or transfer_cap_bytes must be provided"}
 	}
 
 	return textResult("user updated")

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -35,6 +35,7 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 
 	month := currentMonth()
 	out := make([]userWithUsage, 0, len(users))
+	// TODO: replace with BatchGetItem if user count grows large.
 	for _, u := range users {
 		transferUsed, err := h.db.GetTransferUsed(ctx, u.UserID, month)
 		if err != nil {
@@ -66,32 +67,35 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
-	statusStr, err := strArg(args, "status")
-	if err != nil {
-		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
-	}
 
-	status := models.UserStatus(statusStr)
-	switch status {
-	case models.StatusPending, models.StatusUser, models.StatusAdmin, models.StatusBanned:
-	default:
-		return nil, &rpcError{Code: codeInvalidParams, Message: "invalid status value"}
-	}
-
-	if userID == caller.UserID && status != models.StatusAdmin {
-		return errorResult("admins cannot change their own status")
-	}
-
-	if err := h.db.UpdateUserStatus(ctx, userID, status); err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			return errorResult("user not found")
+	// status is optional — omit when only updating caps.
+	statusStr := strArgOpt(args, "status")
+	if statusStr != "" {
+		status := models.UserStatus(statusStr)
+		switch status {
+		case models.StatusPending, models.StatusUser, models.StatusAdmin, models.StatusBanned:
+		default:
+			return nil, &rpcError{Code: codeInvalidParams, Message: "invalid status value"}
 		}
-		return dbErrResult(err)
+
+		if userID == caller.UserID && status != models.StatusAdmin {
+			return errorResult("admins cannot change their own status")
+		}
+
+		if err := h.db.UpdateUserStatus(ctx, userID, status); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return errorResult("user not found")
+			}
+			return dbErrResult(err)
+		}
+		log.Printf("admin: user %s status set to %s", userID, status)
 	}
 
 	// Optional cap overrides. Each field is independent: omit to leave unchanged,
 	// pass -1 to clear the per-user override and restore the server default.
+	anyCap := false
 	if storageCap, hasStorage := int64ArgOpt(args, "storage_cap_bytes"); hasStorage {
+		anyCap = true
 		var capPtr *int64
 		if storageCap >= 0 {
 			capPtr = &storageCap
@@ -105,6 +109,7 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 		}
 	}
 	if transferCap, hasTransfer := int64ArgOpt(args, "transfer_cap_bytes"); hasTransfer {
+		anyCap = true
 		var capPtr *int64
 		if transferCap >= 0 {
 			capPtr = &transferCap
@@ -118,6 +123,9 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 		}
 	}
 
-	log.Printf("admin: user %s status set to %s", userID, status)
+	if statusStr == "" && !anyCap {
+		return nil, &rpcError{Code: codeInvalidParams, Message: "at least one of status, storage_cap_bytes, or transfer_cap_bytes must be provided"}
+	}
+
 	return textResult("user updated")
 }

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -76,8 +76,15 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 	}
 	wg.Wait()
 	close(errc)
+	// Drain all errors — multiple goroutines may have failed.
+	var firstErr error
 	for err := range errc {
 		log.Printf("admin: list users: %v", err)
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr != nil {
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 	return jsonResult(out)

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -90,9 +90,16 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 	}
 
 	// Validate that at least one field is being changed before touching the DB.
+	// Also pre-validate cap types — bad types return -32602 rather than being ignored.
 	statusStr := strArgOpt(args, "status")
-	_, hasStorage := int64ArgOpt(args, "storage_cap_bytes")
-	_, hasTransfer := int64ArgOpt(args, "transfer_cap_bytes")
+	storageCap, hasStorage, storageErr := int64ArgOpt(args, "storage_cap_bytes")
+	transferCap, hasTransfer, transferErr := int64ArgOpt(args, "transfer_cap_bytes")
+	if storageErr != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: storageErr.Error()}
+	}
+	if transferErr != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: transferErr.Error()}
+	}
 	if statusStr == "" && !hasStorage && !hasTransfer {
 		return nil, &rpcError{Code: codeInvalidParams, Message: "at least one of status, storage_cap_bytes, or transfer_cap_bytes must be provided"}
 	}
@@ -121,7 +128,7 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 
 	// Optional cap overrides. Each field is independent: omit to leave unchanged,
 	// pass -1 to clear the per-user override and restore the server default.
-	if storageCap, ok := int64ArgOpt(args, "storage_cap_bytes"); ok {
+	if hasStorage {
 		var capPtr *int64
 		if storageCap >= 0 {
 			capPtr = &storageCap
@@ -134,7 +141,7 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 			return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 		}
 	}
-	if transferCap, ok := int64ArgOpt(args, "transfer_cap_bytes"); ok {
+	if hasTransfer {
 		var capPtr *int64
 		if transferCap >= 0 {
 			capPtr = &transferCap

--- a/internal/handlers/tools_admin.go
+++ b/internal/handlers/tools_admin.go
@@ -43,12 +43,14 @@ func (h *Handler) handleListUsers(ctx context.Context, args map[string]any) (*to
 		storageCap := h.effectiveStorageCap(&u)
 		transferCap := h.effectiveTransferCap(&u)
 		storagePct := 0
-		if storageCap > 0 {
-			storagePct = int(u.StorageUsedBytes * 100 / storageCap)
+		if storageCap > 0 && u.StorageUsedBytes > 0 {
+			// Round up to 1 so any non-zero usage shows as at least 1% rather
+			// than silently appearing as 0 for small values.
+			storagePct = max(1, int(float64(u.StorageUsedBytes)*100/float64(storageCap)))
 		}
 		transferPct := 0
-		if transferCap > 0 {
-			transferPct = int(transferUsed * 100 / transferCap)
+		if transferCap > 0 && transferUsed > 0 {
+			transferPct = max(1, int(float64(transferUsed)*100/float64(transferCap)))
 		}
 		out = append(out, userWithUsage{
 			User:            u,
@@ -87,21 +89,32 @@ func (h *Handler) handleUpdateUser(ctx context.Context, caller *models.User, arg
 		return dbErrResult(err)
 	}
 
-	// Optional cap overrides. Both are nullable: pass -1 to clear, omit to leave unchanged.
-	storageCap, hasStorage := int64ArgOpt(args, "storage_cap_bytes")
-	transferCap, hasTransfer := int64ArgOpt(args, "transfer_cap_bytes")
-	if hasStorage || hasTransfer {
-		var scPtr, tcPtr *int64
-		if hasStorage && storageCap >= 0 {
-			scPtr = &storageCap
+	// Optional cap overrides. Each field is independent: omit to leave unchanged,
+	// pass -1 to clear the per-user override and restore the server default.
+	if storageCap, hasStorage := int64ArgOpt(args, "storage_cap_bytes"); hasStorage {
+		var capPtr *int64
+		if storageCap >= 0 {
+			capPtr = &storageCap
 		}
-		if hasTransfer && transferCap >= 0 {
-			tcPtr = &transferCap
-		}
-		if err := h.db.UpdateUserCaps(ctx, userID, scPtr, tcPtr); err != nil {
-			if !errors.Is(err, db.ErrNotFound) {
-				log.Printf("admin: update caps for %s: %v", userID, err)
+		if err := h.db.UpdateStorageCap(ctx, userID, capPtr); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return errorResult("user not found")
 			}
+			log.Printf("admin: update storage cap for %s: %v", userID, err)
+			return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+		}
+	}
+	if transferCap, hasTransfer := int64ArgOpt(args, "transfer_cap_bytes"); hasTransfer {
+		var capPtr *int64
+		if transferCap >= 0 {
+			capPtr = &transferCap
+		}
+		if err := h.db.UpdateTransferCap(ctx, userID, capPtr); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return errorResult("user not found")
+			}
+			log.Printf("admin: update transfer cap for %s: %v", userID, err)
+			return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 		}
 	}
 

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -69,7 +69,7 @@ func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map
 	// Check and record transfer using the actual response size so both sides
 	// of the enforcement use the same unit.
 	responseBytes := int64(len([]byte(result.Content[0].Text)))
-	transferUsed, rpcErr := h.checkTransferCap(ctx, user)
+	transferUsed, rpcErr := h.readTransferUsed(ctx, user)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -69,11 +69,11 @@ func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map
 	// Check and record transfer using the actual response size so both sides
 	// of the enforcement use the same unit.
 	responseBytes := int64(len([]byte(result.Content[0].Text)))
-	transferUsed, rpcErr := h.readTransferUsed(ctx, user)
+	transferUsedBefore, rpcErr := h.readTransferUsed(ctx, user)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
-	if transferUsed+responseBytes > h.effectiveTransferCap(user) {
+	if transferUsedBefore+responseBytes > h.effectiveTransferCap(user) {
 		return dbErrResult(db.ErrTransferCap)
 	}
 	if _, err := h.db.AddTransferUsed(ctx, user.UserID, currentMonth(), responseBytes, transferTTL()); err != nil {

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -146,6 +146,9 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		return jsonResult(f)
 	}
 
+	// Files written before storage tracking was added have Size==0. Same
+	// migration trade-off as handleSaveNote: first-update overcounts, delete
+	// of a never-updated old file undercounts. Accepted for a soft cap.
 	delta := newSize - existing.Size
 	// Same soft-enforcement trade-off as the create path above.
 	if delta > 0 && user.StorageUsedBytes+delta > h.effectiveStorageCap(user) {

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -136,6 +136,8 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		}
 
 		if err := h.db.SaveFile(ctx, f); err != nil {
+			// S3 object is orphaned (pre-existing behavior) and StorageUsedBytes
+			// is not incremented — intentional, the content wasn't committed.
 			return dbErrResult(err)
 		}
 

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -48,9 +48,19 @@ func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
 
+	transferUsed, rpcErr := h.checkTransferCap(ctx, user)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
 	f, err := h.db.GetFile(ctx, user.UserID, filePath)
 	if err != nil {
 		return dbErrResult(err)
+	}
+
+	contentBytes := f.Size
+	if transferUsed+contentBytes > h.effectiveTransferCap(user) {
+		return dbErrResult(db.ErrTransferCap)
 	}
 
 	content, err := h.store.GetContent(ctx, f.S3Key)
@@ -61,7 +71,17 @@ func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 	f.Content = content
-	return jsonResult(f)
+	result, rpcErr := jsonResult(f)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	responseBytes := int64(len([]byte(result.Content[0].Text)))
+	if _, err := h.db.AddTransferUsed(ctx, user.UserID, currentMonth(), responseBytes, transferTTL()); err != nil {
+		log.Printf("mcp: get file %s: record transfer: %v", filePath, err)
+	}
+
+	return result, nil
 }
 
 func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
@@ -80,6 +100,7 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 	}
 
 	now := time.Now().UTC()
+	newSize := int64(len([]byte(content)))
 	var f *models.File
 
 	existing, dbErr := h.db.GetFile(ctx, user.UserID, filePath)
@@ -89,13 +110,17 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 	// existing is nil iff GetFile returned ErrNotFound; the block below always returns,
 	// so all code after it can safely dereference existing.
 	if existing == nil {
+		if user.StorageUsedBytes+newSize > h.effectiveStorageCap(user) {
+			return dbErrResult(db.ErrStorageCap)
+		}
+
 		f = &models.File{
 			Path:   filePath,
 			UserID: user.UserID,
 			// Same stable-key-on-create trade-off as handleSaveNote; DB enforces
 			// attribute_not_exists on Version==1 writes.
 			S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
-			Size:       int64(len([]byte(content))),
+			Size:       newSize,
 			Version:    1,
 			CreatedAt:  now,
 			ModifiedAt: now,
@@ -113,7 +138,16 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 			return dbErrResult(err)
 		}
 
+		if err := h.db.AddStorageUsed(ctx, user.UserID, newSize); err != nil {
+			log.Printf("mcp: save file %s: update storage used: %v", filePath, err)
+		}
+
 		return jsonResult(f)
+	}
+
+	delta := newSize - existing.Size
+	if delta > 0 && user.StorageUsedBytes+delta > h.effectiveStorageCap(user) {
+		return dbErrResult(db.ErrStorageCap)
 	}
 
 	version := versionArg(args)
@@ -127,7 +161,7 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		UserID: user.UserID,
 		// Fresh S3 key per write: same rationale as handleSaveNote.
 		S3Key:      fmt.Sprintf("files/%s/%s/%s", user.UserID, filePath, newID()),
-		Size:       int64(len([]byte(content))),
+		Size:       newSize,
 		Version:    version,
 		CreatedAt:  existing.CreatedAt,
 		ModifiedAt: now,
@@ -150,6 +184,10 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 	// Log on failure but don't surface the error — the save already succeeded.
 	if err := h.store.DeleteContent(ctx, existing.S3Key); err != nil {
 		log.Printf("mcp: save file %s: cleanup old s3 key %s: %v", filePath, existing.S3Key, err)
+	}
+
+	if err := h.db.AddStorageUsed(ctx, user.UserID, delta); err != nil {
+		log.Printf("mcp: save file %s: update storage used: %v", filePath, err)
 	}
 
 	return jsonResult(f)
@@ -180,6 +218,10 @@ func (h *Handler) handleDeleteFile(ctx context.Context, user *models.User, args 
 	if err := h.store.DeleteContent(ctx, f.S3Key); err != nil {
 		log.Printf("mcp: delete file %s: s3 delete %s: %v", filePath, f.S3Key, err)
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+
+	if err := h.db.AddStorageUsed(ctx, user.UserID, -f.Size); err != nil {
+		log.Printf("mcp: delete file %s: update storage used: %v", filePath, err)
 	}
 
 	return textResult("file deleted")

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -48,19 +48,9 @@ func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
 
-	transferUsed, rpcErr := h.checkTransferCap(ctx, user)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
-
 	f, err := h.db.GetFile(ctx, user.UserID, filePath)
 	if err != nil {
 		return dbErrResult(err)
-	}
-
-	contentBytes := f.Size
-	if transferUsed+contentBytes > h.effectiveTransferCap(user) {
-		return dbErrResult(db.ErrTransferCap)
 	}
 
 	content, err := h.store.GetContent(ctx, f.S3Key)
@@ -76,7 +66,16 @@ func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map
 		return nil, rpcErr
 	}
 
+	// Check and record transfer using the actual response size so both sides
+	// of the enforcement use the same unit.
 	responseBytes := int64(len([]byte(result.Content[0].Text)))
+	transferUsed, rpcErr := h.checkTransferCap(ctx, user)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	if transferUsed+responseBytes > h.effectiveTransferCap(user) {
+		return dbErrResult(db.ErrTransferCap)
+	}
 	if _, err := h.db.AddTransferUsed(ctx, user.UserID, currentMonth(), responseBytes, transferTTL()); err != nil {
 		log.Printf("mcp: get file %s: record transfer: %v", filePath, err)
 	}

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -109,6 +109,8 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 	// existing is nil iff GetFile returned ErrNotFound; the block below always returns,
 	// so all code after it can safely dereference existing.
 	if existing == nil {
+		// user.StorageUsedBytes is from auth middleware (request time);
+		// concurrent saves can both pass this check — soft enforcement accepted.
 		if user.StorageUsedBytes+newSize > h.effectiveStorageCap(user) {
 			return dbErrResult(db.ErrStorageCap)
 		}
@@ -145,6 +147,7 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 	}
 
 	delta := newSize - existing.Size
+	// Same soft-enforcement trade-off as the create path above.
 	if delta > 0 && user.StorageUsedBytes+delta > h.effectiveStorageCap(user) {
 		return dbErrResult(db.ErrStorageCap)
 	}

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -53,6 +53,18 @@ func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map
 		return dbErrResult(err)
 	}
 
+	// Pre-fetch cap check using f.Size (always accurate for files). Avoids an S3
+	// fetch for users who are clearly over cap. The post-fetch check uses the
+	// serialized response size as the metered unit; the pre-fetch check is a
+	// best-effort fast-path that may slightly undercount JSON overhead.
+	transferUsedBefore, rpcErr := h.readTransferUsed(ctx, user)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	if transferUsedBefore+f.Size > h.effectiveTransferCap(user) {
+		return dbErrResult(db.ErrTransferCap)
+	}
+
 	content, err := h.store.GetContent(ctx, f.S3Key)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
@@ -66,13 +78,8 @@ func (h *Handler) handleGetFile(ctx context.Context, user *models.User, args map
 		return nil, rpcErr
 	}
 
-	// Check and record transfer using the actual response size so both sides
-	// of the enforcement use the same unit.
+	// Post-fetch check and record using the actual serialized response size.
 	responseBytes := int64(len([]byte(result.Content[0].Text)))
-	transferUsedBefore, rpcErr := h.readTransferUsed(ctx, user)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
 	if transferUsedBefore+responseBytes > h.effectiveTransferCap(user) {
 		return dbErrResult(db.ErrTransferCap)
 	}

--- a/internal/handlers/tools_files.go
+++ b/internal/handlers/tools_files.go
@@ -191,8 +191,10 @@ func (h *Handler) handleSaveFile(ctx context.Context, user *models.User, args ma
 		log.Printf("mcp: save file %s: cleanup old s3 key %s: %v", filePath, existing.S3Key, err)
 	}
 
-	if err := h.db.AddStorageUsed(ctx, user.UserID, delta); err != nil {
-		log.Printf("mcp: save file %s: update storage used: %v", filePath, err)
+	if delta != 0 {
+		if err := h.db.AddStorageUsed(ctx, user.UserID, delta); err != nil {
+			log.Printf("mcp: save file %s: update storage used: %v", filePath, err)
+		}
 	}
 
 	return jsonResult(f)
@@ -225,8 +227,10 @@ func (h *Handler) handleDeleteFile(ctx context.Context, user *models.User, args 
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 
-	if err := h.db.AddStorageUsed(ctx, user.UserID, -f.Size); err != nil {
-		log.Printf("mcp: delete file %s: update storage used: %v", filePath, err)
+	if f.Size > 0 {
+		if err := h.db.AddStorageUsed(ctx, user.UserID, -f.Size); err != nil {
+			log.Printf("mcp: delete file %s: update storage used: %v", filePath, err)
+		}
 	}
 
 	return textResult("file deleted")

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -30,11 +30,6 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
 
-	transferUsed, rpcErr := h.checkTransferCap(ctx, user)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
-
 	note, err := h.db.GetNote(ctx, user.UserID, noteID)
 	if err != nil {
 		return dbErrResult(err)
@@ -48,18 +43,22 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 
-	contentBytes := int64(len([]byte(content)))
-	if transferUsed+contentBytes > h.effectiveTransferCap(user) {
-		return dbErrResult(db.ErrTransferCap)
-	}
-
 	note.Content = content
 	result, rpcErr := jsonResult(note)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
 
+	// Check and record transfer using the actual response size so both sides
+	// of the enforcement use the same unit.
 	responseBytes := int64(len([]byte(result.Content[0].Text)))
+	transferUsed, rpcErr := h.checkTransferCap(ctx, user)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	if transferUsed+responseBytes > h.effectiveTransferCap(user) {
+		return dbErrResult(db.ErrTransferCap)
+	}
 	if _, err := h.db.AddTransferUsed(ctx, user.UserID, currentMonth(), responseBytes, transferTTL()); err != nil {
 		log.Printf("mcp: get note %s: record transfer: %v", noteID, err)
 	}
@@ -84,7 +83,8 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 	var note *models.Note
 
 	if noteID == "" {
-		// Create path.
+		// Create path. user.StorageUsedBytes is from auth middleware (request time)
+		// so concurrent saves can both pass this check; soft enforcement accepted.
 		if user.StorageUsedBytes+newSize > h.effectiveStorageCap(user) {
 			return dbErrResult(db.ErrStorageCap)
 		}

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -134,7 +134,12 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 	}
 
 	oldSize := existing.Size
+	// Notes written before storage tracking was added have Size==0. On their
+	// first update delta = newSize (overcounts); on delete we subtract 0
+	// (undercounts). StorageUsedBytes is only accurate for items written after
+	// this feature was deployed — accepted for a soft cap.
 	delta := newSize - oldSize
+	// Same soft-enforcement trade-off as the create path above.
 	if delta > 0 && user.StorageUsedBytes+delta > h.effectiveStorageCap(user) {
 		return dbErrResult(db.ErrStorageCap)
 	}

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -35,17 +35,17 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 		return dbErrResult(err)
 	}
 
+	// Read transfer usage once and reuse for both the pre-fetch and post-fetch checks.
+	transferUsedBefore, rpcErr := h.readTransferUsed(ctx, user)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
 	// Pre-fetch cap check using the stored size. Skipped for pre-migration notes
 	// with Size==0 (those proceed to the post-fetch check below). This avoids an
 	// S3 fetch for users who are clearly over cap.
-	if note.Size > 0 {
-		transferUsedBefore, rpcErr := h.readTransferUsed(ctx, user)
-		if rpcErr != nil {
-			return nil, rpcErr
-		}
-		if transferUsedBefore+note.Size > h.effectiveTransferCap(user) {
-			return dbErrResult(db.ErrTransferCap)
-		}
+	if note.Size > 0 && transferUsedBefore+note.Size > h.effectiveTransferCap(user) {
+		return dbErrResult(db.ErrTransferCap)
 	}
 
 	content, err := h.store.GetContent(ctx, note.S3Key)
@@ -65,10 +65,6 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 	// Post-fetch check and record using the actual serialized response size —
 	// the authoritative unit for both the cap check and the meter.
 	responseBytes := int64(len([]byte(result.Content[0].Text)))
-	transferUsedBefore, rpcErr := h.readTransferUsed(ctx, user)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
 	if transferUsedBefore+responseBytes > h.effectiveTransferCap(user) {
 		return dbErrResult(db.ErrTransferCap)
 	}

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/pwntato/notoriousmcp/internal/db"
 	"github.com/pwntato/notoriousmcp/internal/models"
 	"github.com/pwntato/notoriousmcp/internal/store"
 )
@@ -29,6 +30,11 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
 	}
 
+	transferUsed, rpcErr := h.checkTransferCap(ctx, user)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
 	note, err := h.db.GetNote(ctx, user.UserID, noteID)
 	if err != nil {
 		return dbErrResult(err)
@@ -41,8 +47,24 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 		}
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
+
+	contentBytes := int64(len([]byte(content)))
+	if transferUsed+contentBytes > h.effectiveTransferCap(user) {
+		return dbErrResult(db.ErrTransferCap)
+	}
+
 	note.Content = content
-	return jsonResult(note)
+	result, rpcErr := jsonResult(note)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	responseBytes := int64(len([]byte(result.Content[0].Text)))
+	if _, err := h.db.AddTransferUsed(ctx, user.UserID, currentMonth(), responseBytes, transferTTL()); err != nil {
+		log.Printf("mcp: get note %s: record transfer: %v", noteID, err)
+	}
+
+	return result, nil
 }
 
 func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args map[string]any) (*toolsCallResult, *rpcError) {
@@ -58,9 +80,15 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 	noteID := strArgOpt(args, "note_id")
 
 	now := time.Now().UTC()
+	newSize := int64(len([]byte(content)))
 	var note *models.Note
 
 	if noteID == "" {
+		// Create path.
+		if user.StorageUsedBytes+newSize > h.effectiveStorageCap(user) {
+			return dbErrResult(db.ErrStorageCap)
+		}
+
 		noteID = newID()
 		note = &models.Note{
 			ID:     noteID,
@@ -74,38 +102,13 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 			// The DB enforces attribute_not_exists on Version==1 writes, so
 			// concurrent creates for the same ID safely conflict at the DB layer.
 			S3Key:      fmt.Sprintf("notes/%s/%s", user.UserID, noteID),
+			Size:       newSize,
 			Version:    1,
 			CreatedAt:  now,
 			ModifiedAt: now,
 		}
-	} else {
-		existing, err := h.db.GetNote(ctx, user.UserID, noteID)
-		if err != nil {
-			return dbErrResult(err)
-		}
-		version := versionArg(args)
-		if version == 0 {
-			// version omitted: auto-increment bypasses optimistic concurrency.
-			// Callers that need conflict detection must pass the current version.
-			version = existing.Version + 1
-		}
-		note = &models.Note{
-			ID:     noteID,
-			UserID: user.UserID,
-			Title:  title,
-			Tags:   tags,
-			// Fresh S3 key per write: if the DB write fails (version conflict),
-			// the new S3 object is orphaned but the DB record still points to the
-			// previous key, so prior content is never overwritten.
-			S3Key:      fmt.Sprintf("notes/%s/%s/%s", user.UserID, noteID, newID()),
-			Version:    version,
-			CreatedAt:  existing.CreatedAt,
-			ModifiedAt: now,
-		}
 
-		// S3 write precedes DynamoDB write; on DB conflict the new S3 object is
-		// orphaned but the previous version's object is untouched (version-stamped
-		// keys ensure writes never overwrite earlier content).
+		// Create path: stable S3 key, no old object to clean up.
 		if err := h.store.PutContent(ctx, note.S3Key, content); err != nil {
 			if errors.Is(err, store.ErrTooLarge) {
 				return errorResult("content exceeds 1MB limit")
@@ -117,16 +120,49 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 			return dbErrResult(err)
 		}
 
-		// DB write succeeded; delete the now-unreferenced previous S3 object.
-		// Log on failure but don't surface the error — the save already succeeded.
-		if err := h.store.DeleteContent(ctx, existing.S3Key); err != nil {
-			log.Printf("mcp: save note %s: cleanup old s3 key %s: %v", noteID, existing.S3Key, err)
+		if err := h.db.AddStorageUsed(ctx, user.UserID, newSize); err != nil {
+			log.Printf("mcp: save note %s: update storage used: %v", noteID, err)
 		}
 
 		return jsonResult(note)
 	}
 
-	// Create path: stable S3 key, no old object to clean up.
+	// Update path.
+	existing, err := h.db.GetNote(ctx, user.UserID, noteID)
+	if err != nil {
+		return dbErrResult(err)
+	}
+
+	oldSize := existing.Size
+	delta := newSize - oldSize
+	if delta > 0 && user.StorageUsedBytes+delta > h.effectiveStorageCap(user) {
+		return dbErrResult(db.ErrStorageCap)
+	}
+
+	version := versionArg(args)
+	if version == 0 {
+		// version omitted: auto-increment bypasses optimistic concurrency.
+		// Callers that need conflict detection must pass the current version.
+		version = existing.Version + 1
+	}
+	note = &models.Note{
+		ID:     noteID,
+		UserID: user.UserID,
+		Title:  title,
+		Tags:   tags,
+		// Fresh S3 key per write: if the DB write fails (version conflict),
+		// the new S3 object is orphaned but the DB record still points to the
+		// previous key, so prior content is never overwritten.
+		S3Key:      fmt.Sprintf("notes/%s/%s/%s", user.UserID, noteID, newID()),
+		Size:       newSize,
+		Version:    version,
+		CreatedAt:  existing.CreatedAt,
+		ModifiedAt: now,
+	}
+
+	// S3 write precedes DynamoDB write; on DB conflict the new S3 object is
+	// orphaned but the previous version's object is untouched (version-stamped
+	// keys ensure writes never overwrite earlier content).
 	if err := h.store.PutContent(ctx, note.S3Key, content); err != nil {
 		if errors.Is(err, store.ErrTooLarge) {
 			return errorResult("content exceeds 1MB limit")
@@ -136,6 +172,16 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 
 	if err := h.db.SaveNote(ctx, note); err != nil {
 		return dbErrResult(err)
+	}
+
+	// DB write succeeded; delete the now-unreferenced previous S3 object.
+	// Log on failure but don't surface the error — the save already succeeded.
+	if err := h.store.DeleteContent(ctx, existing.S3Key); err != nil {
+		log.Printf("mcp: save note %s: cleanup old s3 key %s: %v", noteID, existing.S3Key, err)
+	}
+
+	if err := h.db.AddStorageUsed(ctx, user.UserID, delta); err != nil {
+		log.Printf("mcp: save note %s: update storage used: %v", noteID, err)
 	}
 
 	return jsonResult(note)
@@ -166,6 +212,10 @@ func (h *Handler) handleDeleteNote(ctx context.Context, user *models.User, args 
 	if err := h.store.DeleteContent(ctx, note.S3Key); err != nil {
 		log.Printf("mcp: delete note %s: s3 delete %s: %v", noteID, note.S3Key, err)
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
+	}
+
+	if err := h.db.AddStorageUsed(ctx, user.UserID, -note.Size); err != nil {
+		log.Printf("mcp: delete note %s: update storage used: %v", noteID, err)
 	}
 
 	return textResult("note deleted")

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -117,6 +117,8 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 		}
 
 		if err := h.db.SaveNote(ctx, note); err != nil {
+			// S3 object is orphaned (pre-existing behavior) and StorageUsedBytes
+			// is not incremented — intentional, the content wasn't committed.
 			return dbErrResult(err)
 		}
 

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -52,7 +52,7 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 	// Check and record transfer using the actual response size so both sides
 	// of the enforcement use the same unit.
 	responseBytes := int64(len([]byte(result.Content[0].Text)))
-	transferUsed, rpcErr := h.checkTransferCap(ctx, user)
+	transferUsed, rpcErr := h.readTransferUsed(ctx, user)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -185,8 +185,10 @@ func (h *Handler) handleSaveNote(ctx context.Context, user *models.User, args ma
 		log.Printf("mcp: save note %s: cleanup old s3 key %s: %v", noteID, existing.S3Key, err)
 	}
 
-	if err := h.db.AddStorageUsed(ctx, user.UserID, delta); err != nil {
-		log.Printf("mcp: save note %s: update storage used: %v", noteID, err)
+	if delta != 0 {
+		if err := h.db.AddStorageUsed(ctx, user.UserID, delta); err != nil {
+			log.Printf("mcp: save note %s: update storage used: %v", noteID, err)
+		}
 	}
 
 	return jsonResult(note)
@@ -219,8 +221,10 @@ func (h *Handler) handleDeleteNote(ctx context.Context, user *models.User, args 
 		return nil, &rpcError{Code: codeInternalError, Message: "internal error"}
 	}
 
-	if err := h.db.AddStorageUsed(ctx, user.UserID, -note.Size); err != nil {
-		log.Printf("mcp: delete note %s: update storage used: %v", noteID, err)
+	if note.Size > 0 {
+		if err := h.db.AddStorageUsed(ctx, user.UserID, -note.Size); err != nil {
+			log.Printf("mcp: delete note %s: update storage used: %v", noteID, err)
+		}
 	}
 
 	return textResult("note deleted")

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -35,6 +35,19 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 		return dbErrResult(err)
 	}
 
+	// Pre-fetch cap check using the stored size. Skipped for pre-migration notes
+	// with Size==0 (those proceed to the post-fetch check below). This avoids an
+	// S3 fetch for users who are clearly over cap.
+	if note.Size > 0 {
+		transferUsedBefore, rpcErr := h.readTransferUsed(ctx, user)
+		if rpcErr != nil {
+			return nil, rpcErr
+		}
+		if transferUsedBefore+note.Size > h.effectiveTransferCap(user) {
+			return dbErrResult(db.ErrTransferCap)
+		}
+	}
+
 	content, err := h.store.GetContent(ctx, note.S3Key)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
@@ -49,8 +62,8 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 		return nil, rpcErr
 	}
 
-	// Check and record transfer using the actual response size so both sides
-	// of the enforcement use the same unit.
+	// Post-fetch check and record using the actual serialized response size —
+	// the authoritative unit for both the cap check and the meter.
 	responseBytes := int64(len([]byte(result.Content[0].Text)))
 	transferUsedBefore, rpcErr := h.readTransferUsed(ctx, user)
 	if rpcErr != nil {

--- a/internal/handlers/tools_notes.go
+++ b/internal/handlers/tools_notes.go
@@ -52,11 +52,11 @@ func (h *Handler) handleGetNote(ctx context.Context, user *models.User, args map
 	// Check and record transfer using the actual response size so both sides
 	// of the enforcement use the same unit.
 	responseBytes := int64(len([]byte(result.Content[0].Text)))
-	transferUsed, rpcErr := h.readTransferUsed(ctx, user)
+	transferUsedBefore, rpcErr := h.readTransferUsed(ctx, user)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
-	if transferUsed+responseBytes > h.effectiveTransferCap(user) {
+	if transferUsedBefore+responseBytes > h.effectiveTransferCap(user) {
 		return dbErrResult(db.ErrTransferCap)
 	}
 	if _, err := h.db.AddTransferUsed(ctx, user.UserID, currentMonth(), responseBytes, transferTTL()); err != nil {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -11,6 +11,11 @@ const (
 	StatusBanned  UserStatus = "banned"
 )
 
+// User is the user profile model. The storage/cap fields are included in JSON
+// because User is only serialized in the admin-only list_users response (via
+// userWithUsage). No public endpoint serializes User directly — check_status
+// returns plain text, and auth middleware only injects User into context.
+// If User is ever serialized in a non-admin context, revisit which fields to expose.
 type User struct {
 	UserID           string     `json:"user_id"             dynamodbav:"UserID"`
 	Email            string     `json:"email"               dynamodbav:"Email"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -12,12 +12,15 @@ const (
 )
 
 type User struct {
-	UserID       string     `json:"user_id"    dynamodbav:"UserID"`
-	Email        string     `json:"email"      dynamodbav:"Email"`
-	Name         string     `json:"name"       dynamodbav:"Name"`
-	Status       UserStatus `json:"status"     dynamodbav:"Status"`
-	RefreshToken string     `json:"-"          dynamodbav:"-"`
-	CreatedAt    time.Time  `json:"created_at" dynamodbav:"CreatedAt"`
+	UserID           string     `json:"user_id"             dynamodbav:"UserID"`
+	Email            string     `json:"email"               dynamodbav:"Email"`
+	Name             string     `json:"name"                dynamodbav:"Name"`
+	Status           UserStatus `json:"status"              dynamodbav:"Status"`
+	RefreshToken     string     `json:"-"                   dynamodbav:"-"`
+	CreatedAt        time.Time  `json:"created_at"          dynamodbav:"CreatedAt"`
+	StorageUsedBytes int64      `json:"storage_used_bytes"  dynamodbav:"StorageUsedBytes"`
+	StorageCapBytes  *int64     `json:"storage_cap_bytes"   dynamodbav:"StorageCapBytes,omitempty"`
+	TransferCapBytes *int64     `json:"transfer_cap_bytes"  dynamodbav:"TransferCapBytes,omitempty"`
 }
 
 type Note struct {
@@ -26,6 +29,7 @@ type Note struct {
 	Title      string    `json:"title"       dynamodbav:"Title"`
 	Tags       []string  `json:"tags"        dynamodbav:"Tags"`
 	S3Key      string    `json:"-"           dynamodbav:"S3Key"`
+	Size       int64     `json:"size"        dynamodbav:"Size"`
 	Version    int       `json:"version"     dynamodbav:"Version"`
 	CreatedAt  time.Time `json:"created_at"  dynamodbav:"CreatedAt"`
 	ModifiedAt time.Time `json:"modified_at" dynamodbav:"ModifiedAt"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -28,6 +28,9 @@ type User struct {
 	TransferCapBytes *int64     `json:"transfer_cap_bytes"  dynamodbav:"TransferCapBytes,omitempty"`
 }
 
+// Note is the note metadata model. Size is intentionally included in JSON —
+// it mirrors File.Size and lets callers make informed decisions before
+// fetching content. Pre-migration notes have Size==0.
 type Note struct {
 	ID         string    `json:"id"          dynamodbav:"ID"`
 	UserID     string    `json:"user_id"     dynamodbav:"UserID"`


### PR DESCRIPTION
Closes #41, #42.

## Summary

- **Storage cap**: `StorageUsedBytes` tracked atomically on the user PROFILE record. Enforced before S3 write on `save_note`/`save_file` (create: full size; update: delta). Decremented on delete. Notes gain a `size` field in the DB record (parallel to `File.Size`).
- **Transfer cap**: Per-user `TRANSFER#YYYY-MM` DynamoDB item, incremented with atomic `ADD` after each successful `get_note`/`get_file`. 60-day TTL for auto-cleanup. Checked (pre-fetch) before serving content.
- **Defaults**: 1 GB for both, overridden by `DEFAULT_STORAGE_CAP_BYTES` / `DEFAULT_TRANSFER_CAP_BYTES` env vars.
- **Per-user overrides**: `update_user` now accepts optional `storage_cap_bytes` / `transfer_cap_bytes`; pass `-1` to clear override and restore server default.
- **Admin visibility**: `list_users` response now includes `storage_used_pct` and `transfer_used_pct` (integer percentage of effective cap).
- `handlers.New()` now takes a `Config` struct.

## Test plan

- [ ] Unit tests: all existing pass, no new unit tests needed (cap logic requires real DB/S3)
- [ ] Integration: `TestIntegrationStorageCapEnforced` — save blocked at 10-byte cap
- [ ] Integration: `TestIntegrationTransferCapEnforced` — get blocked at 1-byte transfer cap
- [ ] Integration: `TestIntegrationUsageVisibleInListUsers` — pct fields present and non-negative after a save
- [ ] All 7 pre-existing integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
