### PR TITLE
fix: resolve Terraform issues found during first deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Binaries
 bin/
 *.exe
+bootstrap
+lambda.zip
+server
 
 # Environment
 .env

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,5 +1,5 @@
 locals {
-  lambda_url_host = replace(aws_lambda_function_url.main.function_url, "https://", "")
+  lambda_url_host = trimsuffix(replace(aws_lambda_function_url.main.function_url, "https://", ""), "/")
   cf_origin_id    = "lambda"
 }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -69,14 +69,14 @@ resource "aws_cloudwatch_log_group" "lambda" {
 }
 
 resource "aws_lambda_function" "main" {
-  function_name                  = "notoriousmcp-${var.environment}"
-  role                           = aws_iam_role.lambda.arn
-  handler                        = "bootstrap"
-  runtime                        = "provided.al2023"
-  architectures                  = ["arm64"]
-  filename                       = "${path.root}/../lambda.zip"
-  timeout     = 30
-  memory_size = 256
+  function_name = "notoriousmcp-${var.environment}"
+  role          = aws_iam_role.lambda.arn
+  handler       = "bootstrap"
+  runtime       = "provided.al2023"
+  architectures = ["arm64"]
+  filename      = "${path.root}/../lambda.zip"
+  timeout       = 30
+  memory_size   = 256
 
   environment {
     variables = {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -75,9 +75,8 @@ resource "aws_lambda_function" "main" {
   runtime                        = "provided.al2023"
   architectures                  = ["arm64"]
   filename                       = "${path.root}/../lambda.zip"
-  timeout                        = 30
-  memory_size                    = 256
-  reserved_concurrent_executions = 10
+  timeout     = 30
+  memory_size = 256
 
   environment {
     variables = {


### PR DESCRIPTION
## Summary

- Remove `reserved_concurrent_executions = 10` from Lambda — fails on new AWS accounts where the unreserved concurrency floor is too low
- Fix CloudFront origin domain name: Lambda Function URL includes a trailing slash that `replace("https://", "")` alone doesn't strip, causing a CloudFront "must be a domain name" error — fixed with `trimsuffix(..., "/")`
- Add `bootstrap`, `lambda.zip`, `server` to `.gitignore` — these are local build artifacts that should not be committed

## Test plan
- [ ] PR merge triggers deploy workflow
- [ ] CI authenticates via OIDC, builds Lambda binary, runs terraform apply successfully
- [ ] CloudFront distribution remains healthy after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)