### PR TITLE
fix: use managed cache/origin-request policies for CloudFront OAC

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -36,17 +36,8 @@ resource "aws_cloudfront_distribution" "main" {
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]
 
-    forwarded_values {
-      query_string = true
-      headers      = ["Authorization", "Content-Type"]
-      cookies {
-        forward = "none"
-      }
-    }
-
-    min_ttl     = 0
-    default_ttl = 0
-    max_ttl     = 0
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AllViewer
   }
 
   viewer_certificate {

--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -93,7 +93,6 @@ data "aws_iam_policy_document" "deploy_policy" {
       "arn:aws:s3:::${aws_s3_bucket.content.bucket}",
       "arn:aws:s3:::${aws_s3_bucket.content.bucket}/*",
       "arn:aws:s3:::${var.state_bucket}",
-      "arn:aws:s3:::${var.state_bucket}/*",
     ]
   }
 


### PR DESCRIPTION
## Summary
- Replaces `forwarded_values` with AWS managed `CachingDisabled` + `AllViewer` policies — the correct setup for CloudFront OAC → Lambda URL (forwarded_values conflicts with OAC SigV4 signing, causing 403 Forbidden)
- Removes `state_bucket/*` from the broad `s3:Get*/s3:List*` statement; state bucket object access is already covered by the dedicated Terraform backend statement

## Test plan
- [ ] CI deploys successfully
- [ ] `https://d2eudgpkavi25i.cloudfront.net/auth/login` loads and redirects to Google
- [ ] Sign in completes and returns to the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)