### PR TITLE
fix: add IAM write permissions to deploy role for terraform apply

### DIFF
--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -115,6 +115,66 @@ data "aws_iam_policy_document" "deploy_policy" {
   # Write permissions for terraform apply
   statement {
     actions = [
+      "cloudfront:CreateOriginAccessControl",
+      "cloudfront:UpdateOriginAccessControl",
+      "cloudfront:DeleteOriginAccessControl",
+      "cloudfront:CreateInvalidation",
+      "cloudfront:UpdateDistribution",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "dynamodb:CreateTable",
+      "dynamodb:UpdateTable",
+      "dynamodb:DeleteTable",
+      "dynamodb:UpdateTimeToLive",
+      "dynamodb:TagResource",
+      "dynamodb:UntagResource",
+    ]
+    resources = ["arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/*"]
+  }
+
+  statement {
+    actions = [
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:CreateOpenIDConnectProvider",
+      "iam:UpdateOpenIDConnectProvider",
+      "iam:DeleteOpenIDConnectProvider",
+      "iam:TagOpenIDConnectProvider",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+      "lambda:AddPermission",
+      "lambda:RemovePermission",
+      "lambda:CreateFunctionUrlConfig",
+      "lambda:UpdateFunctionUrlConfig",
+      "lambda:TagResource",
+    ]
+    resources = [aws_lambda_function.main.arn]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:PutRetentionPolicy",
+      "logs:DeleteLogGroup",
+      "logs:TagLogGroup",
+      "logs:TagResource",
+    ]
+    resources = ["arn:aws:logs:*:${data.aws_caller_identity.current.account_id}:log-group:*"]
+  }
+
+  statement {
+    actions = [
       "s3:PutEncryptionConfiguration",
       "s3:PutBucketVersioning",
       "s3:PutBucketPublicAccessBlock",
@@ -127,30 +187,10 @@ data "aws_iam_policy_document" "deploy_policy" {
   }
 
   statement {
-    actions = [
-      "cloudfront:CreateInvalidation",
-      "cloudfront:UpdateDistribution",
-    ]
-    resources = [aws_cloudfront_distribution.main.arn]
-  }
-
-  statement {
-    actions = [
-      "lambda:UpdateFunctionCode",
-      "lambda:UpdateFunctionConfiguration",
-      "lambda:AddPermission",
-      "lambda:RemovePermission",
-      "lambda:CreateFunctionUrlConfig",
-      "lambda:UpdateFunctionUrlConfig",
-    ]
-    resources = [aws_lambda_function.main.arn]
-  }
-
-  statement {
     # ssm:PutParameter allows CI to rotate OAuth credentials and admin IDs via terraform apply.
     # This is intentional — Terraform manages these values — but means anyone who can push to
     # main (currently only pwntato) can overwrite production secrets.
-    actions = ["ssm:PutParameter"]
+    actions = ["ssm:PutParameter", "ssm:AddTagsToResource"]
     resources = [
       aws_ssm_parameter.google_client_id.arn,
       aws_ssm_parameter.google_client_secret.arn,

--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "deploy_policy" {
       "dynamodb:DescribeContinuousBackups",
       "dynamodb:ListTagsOfResource",
     ]
-    resources = ["arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/*"]
+    resources = ["arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.main.name}"]
   }
 
   statement {
@@ -114,14 +114,20 @@ data "aws_iam_policy_document" "deploy_policy" {
 
   # Write permissions for terraform apply
   statement {
+    # OAC actions require "*" — CloudFront OAC ARNs are not known at policy-definition time.
+    # UpdateDistribution is scoped to the specific distribution ARN below.
     actions = [
       "cloudfront:CreateOriginAccessControl",
       "cloudfront:UpdateOriginAccessControl",
       "cloudfront:DeleteOriginAccessControl",
       "cloudfront:CreateInvalidation",
-      "cloudfront:UpdateDistribution",
     ]
     resources = ["*"]
+  }
+
+  statement {
+    actions   = ["cloudfront:UpdateDistribution"]
+    resources = [aws_cloudfront_distribution.main.arn]
   }
 
   statement {
@@ -133,7 +139,7 @@ data "aws_iam_policy_document" "deploy_policy" {
       "dynamodb:TagResource",
       "dynamodb:UntagResource",
     ]
-    resources = ["arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/*"]
+    resources = ["arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.main.name}"]
   }
 
   statement {
@@ -141,6 +147,16 @@ data "aws_iam_policy_document" "deploy_policy" {
       "iam:PutRolePolicy",
       "iam:DeleteRolePolicy",
       "iam:UpdateAssumeRolePolicy",
+    ]
+    resources = [
+      aws_iam_role.deploy.arn,
+      aws_iam_role.lambda.arn,
+    ]
+  }
+
+  statement {
+    # OIDC provider actions require "*" — AWS does not support resource-level restrictions for OIDCP ARNs.
+    actions = [
       "iam:CreateOpenIDConnectProvider",
       "iam:UpdateOpenIDConnectProvider",
       "iam:DeleteOpenIDConnectProvider",


### PR DESCRIPTION
## Summary
- Adds `iam:PutRolePolicy` / `iam:DeleteRolePolicy` so CI can update the deploy role's own policy
- Adds missing write permissions for all Terraform-managed resources: CloudFront OAC, DynamoDB app table, CloudWatch log group, SSM tagging, IAM OIDC provider lifecycle
- Policy was already applied locally to bootstrap self-management (the apply that was failing is now unblocked)

## Test plan
- [ ] CI deploy succeeds (terraform apply shows "No changes" or applies cleanly)
- [ ] `https://d2eudgpkavi25i.cloudfront.net/auth/login` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)