### PR TITLE
fix: remove custom_origin_config from CloudFront Lambda URL origin

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -21,13 +21,7 @@ resource "aws_cloudfront_distribution" "main" {
     domain_name              = local.lambda_url_host
     origin_id                = local.cf_origin_id
     origin_access_control_id = aws_cloudfront_origin_access_control.lambda.id
-
-    custom_origin_config {
-      http_port              = 80
-      https_port             = 443
-      origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
-    }
+    # No custom_origin_config — Lambda URL origins with OAC must use the default origin config
   }
 
   default_cache_behavior {


### PR DESCRIPTION
## Summary
- Removes `custom_origin_config` from the CloudFront origin for the Lambda URL
- AWS requires Lambda URL origins with OAC to use the **default** origin config — `custom_origin_config` causes CloudFront to treat it as a generic HTTP origin, which breaks OAC SigV4 signing
- Root cause of the `{"Message":null}` / `AccessDeniedException` 403 — Lambda was never being reached (zero invocations in CloudWatch)

## Test plan
- [ ] CI deploys successfully
- [ ] `https://d2eudgpkavi25i.cloudfront.net/auth/login` redirects to Google sign-in
- [ ] CloudWatch logs in us-west-2 show Lambda invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)