### PR TITLE
fix: restore custom_origin_config for CloudFront Lambda URL origin

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -21,7 +21,13 @@ resource "aws_cloudfront_distribution" "main" {
     domain_name              = local.lambda_url_host
     origin_id                = local.cf_origin_id
     origin_access_control_id = aws_cloudfront_origin_access_control.lambda.id
-    # No custom_origin_config — Lambda URL origins with OAC must use the default origin config
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
   }
 
   default_cache_behavior {


### PR DESCRIPTION
## Summary
- Restores `custom_origin_config` removed in PR #64
- Without it, AWS treats the Lambda URL as an S3 origin and rejects the UpdateDistribution call with `InvalidArgument: The parameter Origin DomainName does not refer to a valid S3 bucket`
- The PR #64 apply failed, so the live distribution already has this block — this PR syncs IaC back to match AWS reality (terraform plan shows "No changes")

## Next
The original 403 `AccessDeniedException` needs further investigation — the OAC + `custom_origin_config` combo should work and the resource policy is correct. Likely a propagation timing issue or something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)