### PR TITLE
fix: use AllViewerExceptHostHeader origin request policy for Lambda URL

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -37,7 +37,7 @@ resource "aws_cloudfront_distribution" "main" {
     cached_methods         = ["GET", "HEAD"]
 
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
-    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" # AllViewer
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
   }
 
   viewer_certificate {


### PR DESCRIPTION
## Summary
- Switches origin request policy from `AllViewer` to `AllViewerExceptHostHeader` (`b689b0a8-...`)
- `AllViewer` forwards the viewer's `Host` header to the Lambda URL origin, which conflicts with the `Host` header CloudFront must set to match the Lambda URL domain — causing the OAC SigV4 signing to fail with 403 `AccessDeniedException`
- `AllViewerExceptHostHeader` is the AWS-recommended policy for Lambda URL origins

## Test plan
- [ ] CI deploys successfully
- [ ] `https://d2eudgpkavi25i.cloudfront.net/auth/login` redirects to Google sign-in
- [ ] CloudWatch logs in us-west-2 show Lambda invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)