### PR TITLE
fix: use empty s3_origin_config to enable OAC signing for Lambda URL

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -22,11 +22,11 @@ resource "aws_cloudfront_distribution" "main" {
     origin_id                = local.cf_origin_id
     origin_access_control_id = aws_cloudfront_origin_access_control.lambda.id
 
-    custom_origin_config {
-      http_port              = 80
-      https_port             = 443
-      origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+    # Terraform requires s3_origin_config or custom_origin_config; use an empty
+    # s3_origin_config (no OAI) so the provider is satisfied without adding a
+    # custom_origin_config block, which breaks OAC signing for Lambda URL origins.
+    s3_origin_config {
+      origin_access_identity = ""
     }
   }
 


### PR DESCRIPTION
## Summary
- Replaces `custom_origin_config` with an empty `s3_origin_config` (no OAI) for the Lambda URL origin
- `custom_origin_config` causes CloudFront to treat the origin as a generic HTTPS endpoint, which breaks OAC SigV4 signing — the Lambda URL rejects CloudFront's request with 403
- Removing `custom_origin_config` entirely triggers a Terraform provider validation bug ("not a valid S3 bucket") — the provider requires either `s3_origin_config` or `custom_origin_config` even for Lambda URL origins
- Empty `s3_origin_config` satisfies the provider without adding `custom_origin_config`, allowing OAC to sign correctly

## Test plan
- [ ] CI deploys successfully (terraform apply updates CloudFront distribution)
- [ ] `https://d2eudgpkavi25i.cloudfront.net/auth/login` redirects to Google sign-in
- [ ] CloudWatch logs in us-west-2 show Lambda invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)