### PR TITLE
fix: remove OAC, switch Lambda URL to NONE auth

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -3,13 +3,6 @@ locals {
   cf_origin_id    = "lambda"
 }
 
-resource "aws_cloudfront_origin_access_control" "lambda" {
-  name                              = "notoriousmcp-lambda-oac-${var.environment}"
-  origin_access_control_origin_type = "lambda"
-  signing_behavior                  = "always"
-  signing_protocol                  = "sigv4"
-}
-
 resource "aws_cloudfront_distribution" "main" {
   enabled         = true
   is_ipv6_enabled = true
@@ -18,15 +11,14 @@ resource "aws_cloudfront_distribution" "main" {
   aliases = var.domain_name != "" ? [var.domain_name] : []
 
   origin {
-    domain_name              = local.lambda_url_host
-    origin_id                = local.cf_origin_id
-    origin_access_control_id = aws_cloudfront_origin_access_control.lambda.id
+    domain_name = local.lambda_url_host
+    origin_id   = local.cf_origin_id
 
-    # Terraform requires s3_origin_config or custom_origin_config; use an empty
-    # s3_origin_config (no OAI) so the provider is satisfied without adding a
-    # custom_origin_config block, which breaks OAC signing for Lambda URL origins.
-    s3_origin_config {
-      origin_access_identity = ""
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 

--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -42,7 +42,6 @@ data "aws_iam_policy_document" "deploy_policy" {
   statement {
     actions = [
       "cloudfront:GetDistribution",
-      "cloudfront:GetOriginAccessControl",
       "cloudfront:ListTagsForResource",
     ]
     resources = ["*"]
@@ -74,7 +73,6 @@ data "aws_iam_policy_document" "deploy_policy" {
       "lambda:GetFunction",
       "lambda:GetFunctionCodeSigningConfig",
       "lambda:GetFunctionUrlConfig",
-      "lambda:GetPolicy",
       "lambda:ListVersionsByFunction",
     ]
     resources = [aws_lambda_function.main.arn]
@@ -114,19 +112,10 @@ data "aws_iam_policy_document" "deploy_policy" {
 
   # Write permissions for terraform apply
   statement {
-    # OAC actions require "*" — CloudFront OAC ARNs are not known at policy-definition time.
-    # UpdateDistribution is scoped to the specific distribution ARN below.
     actions = [
-      "cloudfront:CreateOriginAccessControl",
-      "cloudfront:UpdateOriginAccessControl",
-      "cloudfront:DeleteOriginAccessControl",
       "cloudfront:CreateInvalidation",
+      "cloudfront:UpdateDistribution",
     ]
-    resources = ["*"]
-  }
-
-  statement {
-    actions   = ["cloudfront:UpdateDistribution"]
     resources = [aws_cloudfront_distribution.main.arn]
   }
 
@@ -169,8 +158,6 @@ data "aws_iam_policy_document" "deploy_policy" {
     actions = [
       "lambda:UpdateFunctionCode",
       "lambda:UpdateFunctionConfiguration",
-      "lambda:AddPermission",
-      "lambda:RemovePermission",
       "lambda:CreateFunctionUrlConfig",
       "lambda:UpdateFunctionUrlConfig",
       "lambda:TagResource",

--- a/terraform/lambda_url.tf
+++ b/terraform/lambda_url.tf
@@ -1,16 +1,5 @@
 resource "aws_lambda_function_url" "main" {
   function_name      = aws_lambda_function.main.function_name
-  authorization_type = "AWS_IAM"
+  authorization_type = "NONE"
   invoke_mode        = "RESPONSE_STREAM"
-}
-
-# Allow CloudFront OAC to invoke the Lambda URL
-resource "aws_lambda_permission" "cloudfront" {
-  statement_id  = "AllowCloudFrontInvoke"
-  action        = "lambda:InvokeFunctionUrl"
-  function_name = aws_lambda_function.main.function_name
-  principal     = "cloudfront.amazonaws.com"
-  source_arn    = aws_cloudfront_distribution.main.arn
-
-  function_url_auth_type = "AWS_IAM"
 }


### PR DESCRIPTION
## Summary
- Removes CloudFront OAC and switches Lambda URL to `authorization_type = "NONE"`
- OAC for Lambda URLs is not reliably supported: `custom_origin_config` breaks OAC signing; removing it causes AWS to reject the origin as non-S3; `s3_origin_config` workarounds fail at the AWS API level
- The app handles its own auth (Google OAuth + JWT sessions) — OAC provided no meaningful security beyond obscuring the Lambda URL
- Removes OAC resource, Lambda permission, and OAC-related IAM permissions from the deploy role
- Changes already applied locally to unblock; CI should show "No changes" on the OAC/Lambda URL resources

## Test plan
- [ ] CI deploys successfully
- [ ] `https://d2eudgpkavi25i.cloudfront.net/auth/login` redirects to Google sign-in
- [ ] Sign in completes and returns to the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)