### PR TITLE
fix: add required public invoke permissions for NONE auth Lambda URL

### DIFF
--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -158,6 +158,8 @@ data "aws_iam_policy_document" "deploy_policy" {
     actions = [
       "lambda:UpdateFunctionCode",
       "lambda:UpdateFunctionConfiguration",
+      "lambda:AddPermission",
+      "lambda:RemovePermission",
       "lambda:CreateFunctionUrlConfig",
       "lambda:UpdateFunctionUrlConfig",
       "lambda:TagResource",

--- a/terraform/lambda_url.tf
+++ b/terraform/lambda_url.tf
@@ -3,3 +3,20 @@ resource "aws_lambda_function_url" "main" {
   authorization_type = "NONE"
   invoke_mode        = "RESPONSE_STREAM"
 }
+
+# AuthType NONE requires explicit public resource-based policy statements.
+# Since October 2025, both lambda:InvokeFunctionUrl and lambda:InvokeFunction are required.
+resource "aws_lambda_permission" "public_url_invoke_url" {
+  statement_id           = "AllowPublicInvokeFunctionUrl"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.main.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}
+
+resource "aws_lambda_permission" "public_url_invoke" {
+  statement_id  = "AllowPublicInvokeFunction"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.main.function_name
+  principal     = "*"
+}


### PR DESCRIPTION
## Summary
- Adds `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` resource-based policy statements required for `AuthType: NONE` Lambda URLs
- Since October 2025, AWS requires both statements — without them the URL returns 403 even with `AuthType: NONE` configured
- Restores `lambda:AddPermission`/`lambda:RemovePermission` to the deploy IAM role
- Changes applied locally; Lambda URL now returns 302 → Google sign-in as expected

## Note
`aws_lambda_permission` in provider v5.x does not support the `invoked_via_function_url` condition, so `lambda:InvokeFunction` is granted to `Principal: *` without that restriction. Acceptable for a public-facing URL — the function's own auth handles security.

## Test plan
- [ ] CI deploys successfully (no changes on permissions, IAM policy update only)
- [ ] `https://d2eudgpkavi25i.cloudfront.net/auth/login` redirects to Google sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)