### PR TITLE
fix: set reserved concurrency to 5, switch to BUFFERED invoke mode

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -68,19 +68,16 @@ resource "aws_cloudwatch_log_group" "lambda" {
   retention_in_days = 14
 }
 
-# reserved_concurrent_executions is intentionally omitted. New AWS accounts have an
-# unreserved concurrency floor of 10; reserving 10 for this function would push the
-# account below that floor and fail. At personal-use scale, unbounded concurrency
-# is not a practical concern. Add a reservation once your account limit is raised.
 resource "aws_lambda_function" "main" {
-  function_name = "notoriousmcp-${var.environment}"
-  role          = aws_iam_role.lambda.arn
-  handler       = "bootstrap"
-  runtime       = "provided.al2023"
-  architectures = ["arm64"]
-  filename      = "${path.root}/../lambda.zip"
-  timeout       = 30
-  memory_size   = 256
+  function_name                  = "notoriousmcp-${var.environment}"
+  role                           = aws_iam_role.lambda.arn
+  handler                        = "bootstrap"
+  runtime                        = "provided.al2023"
+  architectures                  = ["arm64"]
+  filename                       = "${path.root}/../lambda.zip"
+  timeout                        = 30
+  memory_size                    = 256
+  reserved_concurrent_executions = 5
 
   environment {
     variables = {

--- a/terraform/lambda_url.tf
+++ b/terraform/lambda_url.tf
@@ -1,7 +1,7 @@
 resource "aws_lambda_function_url" "main" {
   function_name      = aws_lambda_function.main.function_name
   authorization_type = "NONE"
-  invoke_mode        = "RESPONSE_STREAM"
+  invoke_mode        = "BUFFERED"
 }
 
 # AuthType NONE requires explicit public resource-based policy statements.


### PR DESCRIPTION
## Summary
- `reserved_concurrent_executions = 5`: caps cost exposure from the public Lambda URL; 5 leaves 5 unreserved on the 10-total account limit
- `invoke_mode: RESPONSE_STREAM → BUFFERED`: CloudFront with `custom_origin_config` passes streaming responses through as raw JSON rather than translating the Lambda proxy response format — auth callback was returning raw `{"statusCode":200,...}` JSON instead of the HTTP redirect

## Test plan
- [ ] CI deploys successfully
- [ ] `https://d2eudgpkavi25i.cloudfront.net/auth/login` redirects to Google sign-in
- [ ] Sign-in completes and returns a proper HTTP response (cookie set, redirect to app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)