### PR TITLE
fix: add lambda:GetPolicy to deploy role, revert reserved concurrency

### DIFF
--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -73,6 +73,7 @@ data "aws_iam_policy_document" "deploy_policy" {
       "lambda:GetFunction",
       "lambda:GetFunctionCodeSigningConfig",
       "lambda:GetFunctionUrlConfig",
+      "lambda:GetPolicy",
       "lambda:ListVersionsByFunction",
     ]
     resources = [aws_lambda_function.main.arn]

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -68,16 +68,18 @@ resource "aws_cloudwatch_log_group" "lambda" {
   retention_in_days = 14
 }
 
+# reserved_concurrent_executions omitted — account limit is 10 total; reserving any
+# would drop unreserved below the 10-minimum and fail. The 10-total cap already
+# bounds abuse. Revisit if the account limit is raised.
 resource "aws_lambda_function" "main" {
-  function_name                  = "notoriousmcp-${var.environment}"
-  role                           = aws_iam_role.lambda.arn
-  handler                        = "bootstrap"
-  runtime                        = "provided.al2023"
-  architectures                  = ["arm64"]
-  filename                       = "${path.root}/../lambda.zip"
-  timeout                        = 30
-  memory_size                    = 256
-  reserved_concurrent_executions = 5
+  function_name = "notoriousmcp-${var.environment}"
+  role          = aws_iam_role.lambda.arn
+  handler       = "bootstrap"
+  runtime       = "provided.al2023"
+  architectures = ["arm64"]
+  filename      = "${path.root}/../lambda.zip"
+  timeout       = 30
+  memory_size   = 256
 
   environment {
     variables = {


### PR DESCRIPTION
## Summary
- Adds `lambda:GetPolicy` back to the deploy role — required for `terraform plan` to read Lambda resource-based policies introduced by the `aws_lambda_permission` resources in PR #69
- Reverts `reserved_concurrent_executions = 5` — account concurrency total is 10; reserving any amount drops unreserved below the 10-minimum floor and AWS rejects it with `InvalidParameterValueException`

## Note on concurrency
The 10-total account limit already bounds cost exposure effectively. If the account limit is raised via Service Quotas in future, reserved concurrency can be added back.

## Test plan
- [ ] CI deploys successfully
- [ ] `https://d2eudgpkavi25i.cloudfront.net/auth/login` redirects to Google and completes sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)