### PR TITLE
Allow localhost redirect URIs and fix refresh token rotation

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -292,23 +292,41 @@ func (h *Handler) callback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, target, http.StatusFound)
 }
 
-// ValidateRedirectURI ensures the client redirect URI exactly matches the
-// server's configured redirect URL (scheme, host, path, and no query string).
-// RFC 6749 §3.1.2 requires exact URI matching. path.Clean neutralises
-// traversal sequences. Query strings are rejected on the client URI because
-// they are not part of a valid callback URL and could be used to smuggle state
-// via an open redirector.
+// ValidateRedirectURI ensures the client redirect URI is one of the two
+// allowed forms (RFC 6749 §3.1.2):
+//
+//  1. Exact match against the server's configured redirect URL (scheme, host,
+//     path, no query string). path.Clean neutralises traversal sequences.
+//
+//  2. http://127.0.0.1:<port>/callback — the loopback redirect form used by
+//     native/CLI OAuth clients (RFC 8252 §7.3). Any port is accepted; the path
+//     must be exactly "/callback". This lets MCP clients (e.g. Claude Code with
+//     --callback-port) register a fixed localhost port without needing a separate
+//     configured redirect URL for each client.
+//
+// Query strings are rejected on the client URI because they are not part of a
+// valid callback URL and could be used to smuggle state via an open redirector.
 func ValidateRedirectURI(configuredRedirectURL, clientRedirectURI string) error {
-	configured, err := url.Parse(configuredRedirectURL)
-	if err != nil {
-		return fmt.Errorf("invalid configured redirect URL: %w", err)
-	}
 	client, err := url.Parse(clientRedirectURI)
 	if err != nil {
 		return fmt.Errorf("invalid redirect_uri: %w", err)
 	}
 	if client.RawQuery != "" {
 		return fmt.Errorf("redirect_uri must not contain a query string")
+	}
+
+	// Loopback form: http://127.0.0.1:<port>/callback
+	if client.Scheme == "http" && client.Hostname() == "127.0.0.1" && path.Clean(client.Path) == "/callback" {
+		if client.Port() == "" {
+			return fmt.Errorf("redirect_uri loopback form requires an explicit port")
+		}
+		return nil
+	}
+
+	// Exact match against the configured redirect URL.
+	configured, err := url.Parse(configuredRedirectURL)
+	if err != nil {
+		return fmt.Errorf("invalid configured redirect URL: %w", err)
 	}
 	if configured.Scheme != client.Scheme ||
 		configured.Host != client.Host ||

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -156,13 +156,22 @@ func tryRefresh(ctx context.Context, cfg Config, dbClient *db.Client, rawToken s
 		return "", "", err
 	}
 
-	if err = exchangeGoogleRefreshToken(ctx, cfg, storedToken); err != nil {
+	rotatedToken, err := exchangeGoogleRefreshToken(ctx, cfg, storedToken)
+	if err != nil {
 		// Token was revoked or otherwise rejected by Google — remove it so future
 		// refresh attempts fail fast without hitting Google unnecessarily.
 		if delErr := dbClient.DeleteRefreshToken(ctx, userID); delErr != nil {
 			log.Printf("auth: delete revoked refresh token for %s: %v", userID, delErr)
 		}
 		return "", "", ErrInvalidToken
+	}
+
+	// Google rotates refresh tokens for inactive users. Persist the new token so
+	// the stored value doesn't silently go stale.
+	if rotatedToken != "" && rotatedToken != storedToken {
+		if saveErr := dbClient.SaveRefreshToken(ctx, userID, rotatedToken); saveErr != nil {
+			log.Printf("auth: save rotated refresh token for %s: %v", userID, saveErr)
+		}
 	}
 
 	newToken, err = IssueAccessToken(cfg.TokenSecret, userID)
@@ -173,18 +182,10 @@ func tryRefresh(ctx context.Context, cfg Config, dbClient *db.Client, rawToken s
 }
 
 // exchangeGoogleRefreshToken performs a live token exchange with Google to
-// confirm the stored refresh token is still valid. It returns nil on success
-// and a non-nil error if Google rejects the token.
-//
-// The Google access token returned by src.Token() is intentionally discarded —
-// the exchange is performed only for liveness validation, not to obtain a
-// Google access token for API calls.
-//
-// Known gap: Google occasionally rotates refresh tokens, returning a new one
-// alongside the access token. That new token is not captured here, so the stored
-// DynamoDB value becomes stale after a rotation. In practice Google only rotates
-// for inactive tokens; regular callers see the same token indefinitely.
-func exchangeGoogleRefreshToken(ctx context.Context, cfg Config, refreshToken string) error {
+// confirm the stored refresh token is still valid. It returns the new refresh
+// token (non-empty only when Google rotates it) and a non-nil error if Google
+// rejects the token.
+func exchangeGoogleRefreshToken(ctx context.Context, cfg Config, refreshToken string) (newRefreshToken string, err error) {
 	endpoint := google.Endpoint
 	if cfg.GoogleTokenURL != "" {
 		endpoint = oauth2.Endpoint{TokenURL: cfg.GoogleTokenURL}
@@ -195,10 +196,11 @@ func exchangeGoogleRefreshToken(ctx context.Context, cfg Config, refreshToken st
 		Endpoint:     endpoint,
 	}
 	src := oauthCfg.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken})
-	if _, err := src.Token(); err != nil {
-		return err
+	tok, err := src.Token()
+	if err != nil {
+		return "", err
 	}
-	return nil
+	return tok.RefreshToken, nil
 }
 
 // responseBuffer is a minimal http.ResponseWriter that captures the response

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -477,6 +477,54 @@ func TestMiddlewareExpiredTokenRefreshBannedUser(t *testing.T) {
 	}
 }
 
+func TestMiddlewareRefreshTokenRotation(t *testing.T) {
+	// When Google returns a new refresh token during exchange, the middleware must
+	// persist it so the stored DynamoDB value stays current.
+	dbClient := newTestDBClient(t)
+	userID := randUID()
+	saveTestUser(t, dbClient, userID, models.StatusUser)
+	if err := dbClient.SaveRefreshToken(context.Background(), userID, "old-google-refresh-token"); err != nil {
+		t.Fatalf("save refresh token: %v", err)
+	}
+
+	expired, err := auth.IssueExpiredToken(testSecret, userID)
+	if err != nil {
+		t.Fatalf("issue expired: %v", err)
+	}
+
+	// Fake Google server returns a *different* refresh token, simulating rotation.
+	rotatedToken := "rotated-google-refresh-token"
+	googleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "google-access-token",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"refresh_token": rotatedToken,
+		})
+	}))
+	defer googleSrv.Close()
+
+	h := auth.Middleware(testMiddlewareCfgWithGoogleURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+expired)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", w.Code)
+	}
+
+	// The rotated token must now be persisted in DynamoDB.
+	stored, err := dbClient.LoadRefreshToken(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("load refresh token after rotation: %v", err)
+	}
+	if stored != rotatedToken {
+		t.Errorf("stored refresh token: got %q want %q", stored, rotatedToken)
+	}
+}
+
 func TestMiddlewareExpiredTokenRevokedRefreshToken(t *testing.T) {
 	// When Google rejects the stored refresh token (revoked), the middleware must
 	// return 401 and delete the token from DynamoDB so future attempts fail fast.

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -525,6 +525,54 @@ func TestMiddlewareRefreshTokenRotation(t *testing.T) {
 	}
 }
 
+func TestMiddlewareRefreshTokenNoRotation(t *testing.T) {
+	// When Google does not rotate the refresh token (empty refresh_token in response),
+	// the stored DynamoDB token must be unchanged — the rotatedToken != "" guard.
+	dbClient := newTestDBClient(t)
+	userID := randUID()
+	saveTestUser(t, dbClient, userID, models.StatusUser)
+	original := "original-google-refresh-token"
+	if err := dbClient.SaveRefreshToken(context.Background(), userID, original); err != nil {
+		t.Fatalf("save refresh token: %v", err)
+	}
+
+	expired, err := auth.IssueExpiredToken(testSecret, userID)
+	if err != nil {
+		t.Fatalf("issue expired: %v", err)
+	}
+
+	// Fake Google server returns no refresh_token field (omitted = empty string in oauth2 lib).
+	googleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "google-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			// refresh_token intentionally omitted
+		})
+	}))
+	defer googleSrv.Close()
+
+	h := auth.Middleware(testMiddlewareCfgWithGoogleURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+expired)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", w.Code)
+	}
+
+	// Stored token must be unchanged — no rotation occurred.
+	stored, err := dbClient.LoadRefreshToken(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("load refresh token: %v", err)
+	}
+	if stored != original {
+		t.Errorf("stored refresh token changed without rotation: got %q want %q", stored, original)
+	}
+}
+
 func TestMiddlewareExpiredTokenRevokedRefreshToken(t *testing.T) {
 	// When Google rejects the stored refresh token (revoked), the middleware must
 	// return 401 and delete the token from DynamoDB so future attempts fail fast.

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -70,34 +70,53 @@ func TestAccessTokenMalformed(t *testing.T) {
 }
 
 func TestValidateRedirectURI(t *testing.T) {
+	configured := "https://notoriousmcp.com/auth/callback"
 	cases := []struct {
-		configured string
-		client     string
-		wantErr    bool
+		name    string
+		client  string
+		wantErr bool
 	}{
-		// Exact match — always allowed
-		{"https://notoriousmcp.com/auth/callback", "https://notoriousmcp.com/auth/callback", false},
-		// Different host — rejected
-		{"https://notoriousmcp.com/auth/callback", "https://evil.com/steal", true},
-		// Scheme mismatch — rejected
-		{"https://notoriousmcp.com/auth/callback", "http://notoriousmcp.com/auth/callback", true},
-		// Path outside configured prefix — rejected
-		{"https://notoriousmcp.com/auth/callback", "https://notoriousmcp.com/other", true},
-		// Path traversal attempt — rejected
-		{"https://notoriousmcp.com/auth/callback", "https://notoriousmcp.com/auth/callback/../../steal", true},
-		// Prefix boundary: /auth/callback-extra must not match /auth/callback
-		{"https://notoriousmcp.com/auth/callback", "https://notoriousmcp.com/auth/callback-extra", true},
-		// Sub-paths also rejected — exact match only (RFC 6749 §3.1.2)
-		{"https://notoriousmcp.com/auth/callback", "https://notoriousmcp.com/auth/callback/sub", true},
-		// Trailing slash normalised by path.Clean — treated as equivalent
-		{"https://notoriousmcp.com/auth/callback", "https://notoriousmcp.com/auth/callback/", false},
-		// Query string on client URI — rejected (RFC 6749 requires exact match, no query)
-		{"https://notoriousmcp.com/auth/callback", "https://notoriousmcp.com/auth/callback?foo=bar", true},
+		// Exact match — always allowed.
+		{"exact match", "https://notoriousmcp.com/auth/callback", false},
+		// Different host — rejected.
+		{"evil domain", "https://evil.com/steal", true},
+		// Scheme mismatch — rejected.
+		{"scheme mismatch", "http://notoriousmcp.com/auth/callback", true},
+		// Path outside configured prefix — rejected.
+		{"wrong path", "https://notoriousmcp.com/other", true},
+		// Path traversal attempt — rejected.
+		{"path traversal", "https://notoriousmcp.com/auth/callback/../../steal", true},
+		// Prefix boundary: /auth/callback-extra must not match /auth/callback.
+		{"prefix boundary", "https://notoriousmcp.com/auth/callback-extra", true},
+		// Sub-paths also rejected — exact match only (RFC 6749 §3.1.2).
+		{"sub-path", "https://notoriousmcp.com/auth/callback/sub", true},
+		// Trailing slash normalised by path.Clean — treated as equivalent.
+		{"trailing slash", "https://notoriousmcp.com/auth/callback/", false},
+		// Query string on client URI — rejected (RFC 6749 requires exact match, no query).
+		{"query string", "https://notoriousmcp.com/auth/callback?foo=bar", true},
+
+		// Loopback form (RFC 8252 §7.3) — any port, must be http://127.0.0.1.
+		{"loopback port 54321", "http://127.0.0.1:54321/callback", false},
+		{"loopback port 8080", "http://127.0.0.1:8080/callback", false},
+		{"loopback port 1", "http://127.0.0.1:1/callback", false},
+		// Loopback without explicit port — rejected.
+		{"loopback no port", "http://127.0.0.1/callback", true},
+		// Wrong path on loopback — rejected.
+		{"loopback wrong path", "http://127.0.0.1:54321/other", true},
+		// Non-127.0.0.1 loopback addresses — rejected (not in Google's allowlist).
+		{"loopback ipv6", "http://[::1]:54321/callback", true},
+		{"localhost hostname", "http://localhost:54321/callback", true},
+		// HTTPS loopback — rejected (Google only registers http://127.0.0.1).
+		{"loopback https", "https://127.0.0.1:54321/callback", true},
+		// Loopback with query string — rejected.
+		{"loopback query string", "http://127.0.0.1:54321/callback?foo=bar", true},
 	}
 	for _, tc := range cases {
-		err := auth.ValidateRedirectURI(tc.configured, tc.client)
-		if (err != nil) != tc.wantErr {
-			t.Errorf("ValidateRedirectURI(%q, %q): err=%v wantErr=%v", tc.configured, tc.client, err, tc.wantErr)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			err := auth.ValidateRedirectURI(configured, tc.client)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateRedirectURI(%q): err=%v wantErr=%v", tc.client, err, tc.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #72

## Changes

### `ValidateRedirectURI` — allow `http://127.0.0.1:<port>/callback`

In addition to the existing exact-match against the configured `REDIRECT_URL`, the validator now also accepts `http://127.0.0.1:<port>/callback` for any explicit port. This is the loopback redirect form used by native/CLI OAuth clients per RFC 8252 §7.3 — Google accepts `http://127.0.0.1` as a wildcard-port URI in its authorized redirect URIs list.

Rejected forms: no-port loopback, HTTPS loopback, IPv6 `[::1]`, `localhost` hostname, wrong path, query strings. All covered by new test cases in `TestValidateRedirectURI`.

### `exchangeGoogleRefreshToken` — capture and persist rotated tokens

Google occasionally returns a new refresh token during exchange (token rotation). Previously `exchangeGoogleRefreshToken` returned `void` and discarded it; now it returns the new token and `tryRefresh` persists it via `SaveRefreshToken` when it differs from the stored value. Prevents silent re-auth failures after a rotation event.

New test: `TestMiddlewareRefreshTokenRotation` (integration, requires `DYNAMODB_ENDPOINT`).

## Manual step after merge + deploy

Add `http://127.0.0.1` to the authorized redirect URIs in Google Cloud Console for the OAuth client. Then configure Claude Code:

```
claude mcp add --transport http --scope user --callback-port 54321 notoriousmcp https://d2eudgpkavi25i.cloudfront.net/mcp
```

## Test plan
- [x] `TestValidateRedirectURI` — 18 sub-cases covering all loopback variants and rejection cases
- [x] `TestMiddlewareRefreshTokenRotation` — verifies rotated token is persisted to DynamoDB
- [x] All existing auth unit tests pass
- [ ] CI integration tests (DynamoDB) pass on merge