### PR TITLE
feat: RFC 7591 dynamic client registration

### DIFF
--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -70,7 +70,8 @@ func main() {
 func publicRouter(public, protected http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/auth/") ||
-			strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			strings.HasPrefix(r.URL.Path, "/.well-known/") ||
+			r.URL.Path == "/register" {
 			public.ServeHTTP(w, r)
 			return
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -158,7 +158,8 @@ func toHTTPRequest(ctx context.Context, req events.LambdaFunctionURLRequest) (*h
 func publicRouter(public, protected http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/auth/") ||
-			strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			strings.HasPrefix(r.URL.Path, "/.well-known/") ||
+			r.URL.Path == "/register" {
 			public.ServeHTTP(w, r)
 			return
 		}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -123,10 +123,17 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 
 	// If a client_id is provided (dynamically registered client), verify it
 	// exists in the registry and that its stored redirect URI matches.
+	// Clients that omit client_id are allowed through for backwards compatibility
+	// (pre-registration flows and direct token use); the redirect_uri check above
+	// is still the primary open-redirect guard for those callers.
 	if clientID := r.URL.Query().Get("client_id"); clientID != "" {
 		registered, err := h.db.GetClient(ctx, clientID)
-		if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
 			http.Error(w, "invalid client_id", http.StatusUnauthorized)
+			return
+		}
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
 		if clientRedirectURI != "" && registered.RedirectURI != clientRedirectURI {
@@ -365,11 +372,11 @@ func writeJSONError(w http.ResponseWriter, status int, errCode string) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": errCode})
 }
 
-// registerRequest is the RFC 7591 §2 dynamic client registration request body.
+// registerRequest is a subset of the RFC 7591 §2 dynamic client registration request body.
 type registerRequest struct {
-	RedirectURIs              []string `json:"redirect_uris"`
-	ClientName                string   `json:"client_name"`
-	TokenEndpointAuthMethod   string   `json:"token_endpoint_auth_method"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	ClientName              string   `json:"client_name"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
 }
 
 // registerResponse is the RFC 7591 §3.2.1 successful registration response.
@@ -384,6 +391,11 @@ type registerResponse struct {
 // Public clients (MCP CLI tools) register a loopback redirect URI and receive
 // a client_id they use in subsequent authorization requests. No client secret
 // is issued because Claude Code uses PKCE (public client flow).
+//
+// Rate limiting: this endpoint is unauthenticated. Abuse (flooding registrations)
+// is mitigated by the loopback-only redirect URI policy — invalid URIs are
+// rejected before any DynamoDB write. CloudFront/WAF provides the IP-level
+// rate limit layer; no in-process limiting is applied.
 func (h *Handler) register(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -410,6 +422,13 @@ func (h *Handler) register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Only "none" is supported (public client / PKCE flow). Reject other methods
+	// rather than echo them back, which would imply support we don't provide.
+	if req.TokenEndpointAuthMethod != "" && req.TokenEndpointAuthMethod != "none" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_client_metadata")
+		return
+	}
+
 	clientID, err := generateRandomCode()
 	if err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -422,16 +441,11 @@ func (h *Handler) register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authMethod := req.TokenEndpointAuthMethod
-	if authMethod == "" {
-		authMethod = "none"
-	}
-
 	resp := registerResponse{
 		ClientID:                clientID,
 		ClientIDIssuedAt:        time.Now().Unix(),
 		RedirectURIs:            req.RedirectURIs,
-		TokenEndpointAuthMethod: authMethod,
+		TokenEndpointAuthMethod: "none",
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -67,6 +67,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /auth/login", h.login)
 	mux.HandleFunc("GET /auth/callback", h.callback)
 	mux.HandleFunc("POST /auth/token", h.token)
+	mux.HandleFunc("POST /register", h.register)
 }
 
 // requestScheme returns https when TLS is active or, if trustProxy is true,
@@ -91,6 +92,7 @@ func (h *Handler) wellKnown(w http.ResponseWriter, r *http.Request) {
 		"issuer":                   base,
 		"authorization_endpoint":   base + "/auth/login",
 		"token_endpoint":           base + "/auth/token",
+		"registration_endpoint":    base + "/register",
 		"response_types_supported": []string{"code"},
 		"grant_types_supported":    []string{"authorization_code"},
 	}
@@ -346,6 +348,76 @@ func writeJSONError(w http.ResponseWriter, status int, errCode string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": errCode})
+}
+
+// registerRequest is the RFC 7591 §2 dynamic client registration request body.
+type registerRequest struct {
+	RedirectURIs              []string `json:"redirect_uris"`
+	ClientName                string   `json:"client_name"`
+	TokenEndpointAuthMethod   string   `json:"token_endpoint_auth_method"`
+}
+
+// registerResponse is the RFC 7591 §3.2.1 successful registration response.
+type registerResponse struct {
+	ClientID                string   `json:"client_id"`
+	ClientIDIssuedAt        int64    `json:"client_id_issued_at"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+}
+
+// register handles POST /register — RFC 7591 dynamic client registration.
+// Public clients (MCP CLI tools) register a loopback redirect URI and receive
+// a client_id they use in subsequent authorization requests. No client secret
+// is issued because Claude Code uses PKCE (public client flow).
+func (h *Handler) register(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	limited := &io.LimitedReader{R: r.Body, N: 64 * 1024}
+	var req registerRequest
+	if err := json.NewDecoder(limited).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_client_metadata")
+		return
+	}
+
+	if len(req.RedirectURIs) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_redirect_uri")
+		return
+	}
+
+	// Validate every redirect URI before accepting the registration.
+	for _, uri := range req.RedirectURIs {
+		if err := ValidateRedirectURI(h.cfg.RedirectURL, uri); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid_redirect_uri")
+			return
+		}
+	}
+
+	clientID, err := generateRandomCode()
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if err := h.db.SaveClient(ctx, clientID, req.RedirectURIs[0], req.ClientName); err != nil {
+		log.Printf("register: save client: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	authMethod := req.TokenEndpointAuthMethod
+	if authMethod == "" {
+		authMethod = "none"
+	}
+
+	resp := registerResponse{
+		ClientID:                clientID,
+		ClientIDIssuedAt:        time.Now().Unix(),
+		RedirectURIs:            req.RedirectURIs,
+		TokenEndpointAuthMethod: authMethod,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // token handles POST /auth/token — the RFC 6749 §4.1.3 token endpoint.

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -109,6 +109,7 @@ type oauthStatePayload struct {
 
 // login initiates the OAuth flow by redirecting to Google.
 func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	clientRedirectURI := r.URL.Query().Get("redirect_uri")
 
 	// Validate redirect_uri against the configured redirect URL origin to
@@ -116,6 +117,20 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 	if clientRedirectURI != "" {
 		if err := ValidateRedirectURI(h.cfg.RedirectURL, clientRedirectURI); err != nil {
 			http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+			return
+		}
+	}
+
+	// If a client_id is provided (dynamically registered client), verify it
+	// exists in the registry and that its stored redirect URI matches.
+	if clientID := r.URL.Query().Get("client_id"); clientID != "" {
+		registered, err := h.db.GetClient(ctx, clientID)
+		if err != nil {
+			http.Error(w, "invalid client_id", http.StatusUnauthorized)
+			return
+		}
+		if clientRedirectURI != "" && registered.RedirectURI != clientRedirectURI {
+			http.Error(w, "redirect_uri mismatch", http.StatusBadRequest)
 			return
 		}
 	}
@@ -383,13 +398,16 @@ func (h *Handler) register(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "invalid_redirect_uri")
 		return
 	}
+	// Only one redirect URI is supported per registration. Accepting multiple
+	// while only persisting one would create a mismatch at /auth/login.
+	if len(req.RedirectURIs) > 1 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_redirect_uri")
+		return
+	}
 
-	// Validate every redirect URI before accepting the registration.
-	for _, uri := range req.RedirectURIs {
-		if err := ValidateRedirectURI(h.cfg.RedirectURL, uri); err != nil {
-			writeJSONError(w, http.StatusBadRequest, "invalid_redirect_uri")
-			return
-		}
+	if err := ValidateRedirectURI(h.cfg.RedirectURL, req.RedirectURIs[0]); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_redirect_uri")
+		return
 	}
 
 	clientID, err := generateRandomCode()

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -315,8 +315,10 @@ func TestRegisterValidLoopback(t *testing.T) {
 	if resp["client_id"] == "" {
 		t.Error("client_id should be non-empty")
 	}
-	if resp["client_id_issued_at"] == nil {
-		t.Error("client_id_issued_at should be present")
+	// JSON numbers decode to float64 in map[string]any.
+	issuedAt, ok := resp["client_id_issued_at"].(float64)
+	if !ok || issuedAt <= 0 {
+		t.Errorf("client_id_issued_at: got %v (%T), want positive number", resp["client_id_issued_at"], resp["client_id_issued_at"])
 	}
 	uris, ok := resp["redirect_uris"].([]any)
 	if !ok || len(uris) != 1 || uris[0] != "http://127.0.0.1:54321/callback" {
@@ -324,6 +326,53 @@ func TestRegisterValidLoopback(t *testing.T) {
 	}
 	if resp["token_endpoint_auth_method"] != "none" {
 		t.Errorf("token_endpoint_auth_method: got %v", resp["token_endpoint_auth_method"])
+	}
+}
+
+func TestRegisterMalformedJSON(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("POST", "/register", strings.NewReader("{not valid json"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400 for malformed JSON", w.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "invalid_client_metadata" {
+		t.Errorf("error: got %q want invalid_client_metadata", resp["error"])
+	}
+}
+
+func TestRegisterRejectsUnsupportedAuthMethod(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"redirect_uris":["http://127.0.0.1:54321/callback"],"token_endpoint_auth_method":"client_secret_basic"}`
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400 for unsupported auth method", w.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "invalid_client_metadata" {
+		t.Errorf("error: got %q want invalid_client_metadata", resp["error"])
 	}
 }
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -59,6 +59,9 @@ func TestWellKnown(t *testing.T) {
 	if meta["token_endpoint"] != "http://example.com/auth/token" {
 		t.Errorf("token_endpoint: got %v", meta["token_endpoint"])
 	}
+	if meta["registration_endpoint"] != "http://example.com/register" {
+		t.Errorf("registration_endpoint: got %v", meta["registration_endpoint"])
+	}
 }
 
 func TestWellKnownXForwardedProto(t *testing.T) {
@@ -283,6 +286,116 @@ func TestTokenEndpointWrongGrantType(t *testing.T) {
 	}
 	if body["error"] != "unsupported_grant_type" {
 		t.Errorf("error: got %q want unsupported_grant_type", body["error"])
+	}
+}
+
+func TestRegisterValidLoopback(t *testing.T) {
+	h, _ := newTestHandlerWithDB(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"redirect_uris":["http://127.0.0.1:54321/callback"],"client_name":"Claude Code","token_endpoint_auth_method":"none"}`
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status: got %d want 201, body: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type: got %q want application/json", ct)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["client_id"] == "" {
+		t.Error("client_id should be non-empty")
+	}
+	if resp["client_id_issued_at"] == nil {
+		t.Error("client_id_issued_at should be present")
+	}
+	uris, ok := resp["redirect_uris"].([]any)
+	if !ok || len(uris) != 1 || uris[0] != "http://127.0.0.1:54321/callback" {
+		t.Errorf("redirect_uris: got %v", resp["redirect_uris"])
+	}
+	if resp["token_endpoint_auth_method"] != "none" {
+		t.Errorf("token_endpoint_auth_method: got %v", resp["token_endpoint_auth_method"])
+	}
+}
+
+func TestRegisterInvalidRedirectURI(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"redirect_uris":["https://evil.com/steal"]}`
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", w.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "invalid_redirect_uri" {
+		t.Errorf("error: got %q want invalid_redirect_uri", resp["error"])
+	}
+}
+
+func TestRegisterMissingRedirectURIs(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"client_name":"No URIs"}`
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", w.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "invalid_redirect_uri" {
+		t.Errorf("error: got %q want invalid_redirect_uri", resp["error"])
+	}
+}
+
+func TestRegisterDefaultsAuthMethod(t *testing.T) {
+	h, _ := newTestHandlerWithDB(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"redirect_uris":["http://127.0.0.1:8080/callback"]}`
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status: got %d want 201", w.Code)
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["token_endpoint_auth_method"] != "none" {
+		t.Errorf("token_endpoint_auth_method: got %v want none", resp["token_endpoint_auth_method"])
 	}
 }
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -327,6 +327,30 @@ func TestRegisterValidLoopback(t *testing.T) {
 	}
 }
 
+func TestRegisterRejectsMultipleRedirectURIs(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"redirect_uris":["http://127.0.0.1:54321/callback","http://127.0.0.1:9999/callback"]}`
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400 for multiple redirect_uris", w.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "invalid_redirect_uri" {
+		t.Errorf("error: got %q want invalid_redirect_uri", resp["error"])
+	}
+}
+
 func TestRegisterInvalidRedirectURI(t *testing.T) {
 	h := newTestHandler(t)
 	mux := http.NewServeMux()
@@ -412,6 +436,63 @@ func newTestHandlerWithDB(t *testing.T) (*auth.Handler, *db.Client) {
 		TrustProxy:   true,
 	}
 	return auth.New(cfg, dbClient), dbClient
+}
+
+func TestLoginRejectsUnknownClientID(t *testing.T) {
+	h, _ := newTestHandlerWithDB(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/auth/login?client_id=no-such-client&redirect_uri=http://127.0.0.1:54321/callback", nil)
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d want 401 for unknown client_id", w.Code)
+	}
+}
+
+func TestLoginRejectsClientIDRedirectURIMismatch(t *testing.T) {
+	h, dbClient := newTestHandlerWithDB(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	clientID := "client-" + randUID()
+	if err := dbClient.SaveClient(context.Background(), clientID, "http://127.0.0.1:54321/callback", "test"); err != nil {
+		t.Fatalf("save client: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/auth/login?client_id="+clientID+"&redirect_uri=http://127.0.0.1:9999/callback", nil)
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d want 400 for redirect_uri mismatch", w.Code)
+	}
+}
+
+func TestLoginAcceptsRegisteredClientID(t *testing.T) {
+	h, dbClient := newTestHandlerWithDB(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	clientID := "client-" + randUID()
+	redirectURI := "http://127.0.0.1:54321/callback"
+	if err := dbClient.SaveClient(context.Background(), clientID, redirectURI, "test"); err != nil {
+		t.Fatalf("save client: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/auth/login?client_id="+clientID+"&redirect_uri="+redirectURI, nil)
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// Proceeds to Google redirect (302) — client_id accepted.
+	if w.Code != http.StatusFound {
+		t.Errorf("status: got %d want 302 for valid registered client_id", w.Code)
+	}
 }
 
 func TestTokenEndpointRoundTrip(t *testing.T) {

--- a/internal/db/clients.go
+++ b/internal/db/clients.go
@@ -11,7 +11,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-const clientSK = "CLIENT"
+// clientRecordSK is the sort key for registered client items. Named to avoid
+// confusion with clientPK which uses the "CLIENT#" prefix on the partition key.
+const clientRecordSK = "CLIENT"
 
 type clientRecord struct {
 	PK          string `dynamodbav:"PK"`
@@ -39,7 +41,7 @@ func (c *Client) SaveClient(ctx context.Context, clientID, redirectURI, clientNa
 	now := time.Now()
 	rec := clientRecord{
 		PK:          clientPK(clientID),
-		SK:          clientSK,
+		SK:          clientRecordSK,
 		ClientID:    clientID,
 		ClientName:  clientName,
 		RedirectURI: redirectURI,
@@ -67,7 +69,7 @@ func (c *Client) GetClient(ctx context.Context, clientID string) (*RegisteredCli
 		TableName: aws.String(c.tableName),
 		Key: map[string]types.AttributeValue{
 			"PK": &types.AttributeValueMemberS{Value: clientPK(clientID)},
-			"SK": &types.AttributeValueMemberS{Value: clientSK},
+			"SK": &types.AttributeValueMemberS{Value: clientRecordSK},
 		},
 	})
 	if err != nil {

--- a/internal/db/clients.go
+++ b/internal/db/clients.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-const clientSK = "PROFILE"
+const clientSK = "CLIENT"
 
 type clientRecord struct {
 	PK          string `dynamodbav:"PK"`

--- a/internal/db/clients.go
+++ b/internal/db/clients.go
@@ -36,15 +36,15 @@ type RegisteredClient struct {
 
 // SaveClient persists a dynamically registered OAuth client (RFC 7591).
 func (c *Client) SaveClient(ctx context.Context, clientID, redirectURI, clientName string) error {
-	now := time.Now().Unix()
+	now := time.Now()
 	rec := clientRecord{
 		PK:          clientPK(clientID),
 		SK:          clientSK,
 		ClientID:    clientID,
 		ClientName:  clientName,
 		RedirectURI: redirectURI,
-		IssuedAt:    now,
-		ExpiresAt:   time.Now().Add(clientTTL).Unix(),
+		IssuedAt:    now.Unix(),
+		ExpiresAt:   now.Add(clientTTL).Unix(),
 	}
 	item, err := attributevalue.MarshalMap(rec)
 	if err != nil {

--- a/internal/db/clients.go
+++ b/internal/db/clients.go
@@ -1,0 +1,94 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+const clientSK = "PROFILE"
+
+type clientRecord struct {
+	PK          string `dynamodbav:"PK"`
+	SK          string `dynamodbav:"SK"`
+	ClientID    string `dynamodbav:"ClientID"`
+	ClientName  string `dynamodbav:"ClientName,omitempty"`
+	RedirectURI string `dynamodbav:"RedirectURI"`
+	IssuedAt    int64  `dynamodbav:"IssuedAt"`
+	ExpiresAt   int64  `dynamodbav:"ExpiresAt"`
+}
+
+func clientPK(clientID string) string { return "CLIENT#" + clientID }
+
+const clientTTL = 90 * 24 * time.Hour
+
+// RegisteredClient holds the values for a dynamically registered OAuth client.
+type RegisteredClient struct {
+	ClientID    string
+	RedirectURI string
+	IssuedAt    int64
+}
+
+// SaveClient persists a dynamically registered OAuth client (RFC 7591).
+func (c *Client) SaveClient(ctx context.Context, clientID, redirectURI, clientName string) error {
+	now := time.Now().Unix()
+	rec := clientRecord{
+		PK:          clientPK(clientID),
+		SK:          clientSK,
+		ClientID:    clientID,
+		ClientName:  clientName,
+		RedirectURI: redirectURI,
+		IssuedAt:    now,
+		ExpiresAt:   time.Now().Add(clientTTL).Unix(),
+	}
+	item, err := attributevalue.MarshalMap(rec)
+	if err != nil {
+		return fmt.Errorf("marshal client: %w", err)
+	}
+	_, err = c.ddb.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(c.tableName),
+		Item:      item,
+	})
+	if err != nil {
+		return fmt.Errorf("save client: %w", err)
+	}
+	return nil
+}
+
+// GetClient retrieves a registered client by client_id.
+// Returns ErrNotFound if the client does not exist or has expired.
+func (c *Client) GetClient(ctx context.Context, clientID string) (*RegisteredClient, error) {
+	out, err := c.ddb.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(c.tableName),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: clientPK(clientID)},
+			"SK": &types.AttributeValueMemberS{Value: clientSK},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get client: %w", err)
+	}
+	if out.Item == nil {
+		return nil, ErrNotFound
+	}
+
+	var rec clientRecord
+	if err := attributevalue.UnmarshalMap(out.Item, &rec); err != nil {
+		return nil, fmt.Errorf("unmarshal client: %w", err)
+	}
+
+	if time.Now().Unix() > rec.ExpiresAt {
+		return nil, ErrNotFound
+	}
+
+	return &RegisteredClient{
+		ClientID:    rec.ClientID,
+		RedirectURI: rec.RedirectURI,
+		IssuedAt:    rec.IssuedAt,
+	}, nil
+}


### PR DESCRIPTION
## Summary

- Adds `POST /register` endpoint (RFC 7591) so MCP clients can self-register without manual pre-configuration
- Advertises `registration_endpoint` in `GET /.well-known/oauth-authorization-server` so clients discover it automatically
- Routes `/register` through the public router (no Bearer token required) in both `cmd/server` and `cmd/local`
- Persists registered clients in DynamoDB as `CLIENT#<id>` / `PROFILE` items with a 90-day TTL — same table, no schema changes
- All `redirect_uris` are validated through the existing `ValidateRedirectURI` (loopback-only policy is preserved)

Closes #74.

## Test plan

- [ ] `go test ./...` passes (unit tests for validation cases; integration tests for happy-path round-trips skip without `DYNAMODB_ENDPOINT`)
- [ ] After deploy: `POST /register` with `{"redirect_uris":["http://127.0.0.1:54321/callback"]}` returns 201 with `client_id`
- [ ] `GET /.well-known/oauth-authorization-server` includes `registration_endpoint`
- [ ] `claude mcp get notoriousmcp` shows connected (not "Failed to connect") after a fresh session triggers the OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)