### PR TITLE
fix: add WWW-Authenticate header and /.well-known/oauth-protected-resource

### DIFF
--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -1,6 +1,10 @@
 package auth
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
 
 // Config holds OAuth credentials and server settings needed by the auth layer.
 // Call Validate() before passing to New().
@@ -22,6 +26,15 @@ type Config struct {
 	// GoogleTokenURL overrides Google's token endpoint. Empty means use the
 	// default (google.Endpoint). Set in tests only to point at a fake server.
 	GoogleTokenURL string
+}
+
+// publicBase returns the canonical public base URL with no trailing slash.
+// Uses PublicBaseURL when set; otherwise derives it from the request.
+func (c Config) publicBase(r *http.Request) string {
+	if c.PublicBaseURL != "" {
+		return strings.TrimRight(c.PublicBaseURL, "/")
+	}
+	return strings.TrimRight(requestScheme(r, c.TrustProxy)+"://"+r.Host, "/")
 }
 
 // Validate returns an error if any required field is missing or too short.

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -64,6 +64,7 @@ func New(cfg Config, dbClient *db.Client) *Handler {
 // RegisterRoutes wires the auth endpoints onto the given mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server", h.wellKnown)
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource", h.protectedResource)
 	mux.HandleFunc("GET /auth/login", h.login)
 	mux.HandleFunc("GET /auth/callback", h.callback)
 	mux.HandleFunc("POST /auth/token", h.token)
@@ -99,6 +100,23 @@ func (h *Handler) wellKnown(w http.ResponseWriter, r *http.Request) {
 		"registration_endpoint":    base + "/register",
 		"response_types_supported": []string{"code"},
 		"grant_types_supported":    []string{"authorization_code"},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(meta)
+}
+
+// protectedResource serves the OAuth 2.0 Protected Resource Metadata (RFC 9728).
+// Claude Code's MCP SDK reads this document (linked from the WWW-Authenticate header
+// on 401 responses) to discover the authorization server before starting OAuth.
+func (h *Handler) protectedResource(w http.ResponseWriter, r *http.Request) {
+	base := h.cfg.PublicBaseURL
+	if base == "" {
+		base = requestScheme(r, h.cfg.TrustProxy) + "://" + r.Host
+	}
+	base = strings.TrimRight(base, "/")
+	meta := map[string]any{
+		"resource":               base,
+		"authorization_servers": []string{base},
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(meta)

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -88,11 +88,7 @@ func requestScheme(r *http.Request, trustProxy bool) string {
 
 // wellKnown serves the OAuth 2.0 authorization server metadata required by the MCP spec.
 func (h *Handler) wellKnown(w http.ResponseWriter, r *http.Request) {
-	base := h.cfg.PublicBaseURL
-	if base == "" {
-		base = requestScheme(r, h.cfg.TrustProxy) + "://" + r.Host
-	}
-	base = strings.TrimRight(base, "/")
+	base := h.cfg.publicBase(r)
 	meta := map[string]any{
 		"issuer":                   base,
 		"authorization_endpoint":   base + "/auth/login",
@@ -109,11 +105,7 @@ func (h *Handler) wellKnown(w http.ResponseWriter, r *http.Request) {
 // Claude Code's MCP SDK reads this document (linked from the WWW-Authenticate header
 // on 401 responses) to discover the authorization server before starting OAuth.
 func (h *Handler) protectedResource(w http.ResponseWriter, r *http.Request) {
-	base := h.cfg.PublicBaseURL
-	if base == "" {
-		base = requestScheme(r, h.cfg.TrustProxy) + "://" + r.Host
-	}
-	base = strings.TrimRight(base, "/")
+	base := h.cfg.publicBase(r)
 	meta := map[string]any{
 		"resource":               base,
 		"authorization_servers": []string{base},

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -271,10 +271,6 @@ func validSignatureUserID(secret []byte, token string) (string, error) {
 // (OAuth 2.0 Protected Resource Metadata). Claude Code's MCP SDK reads the
 // resource_metadata URL to discover the authorization server before starting OAuth.
 func setWWWAuthenticate(w http.ResponseWriter, r *http.Request, cfg Config) {
-	base := cfg.PublicBaseURL
-	if base == "" {
-		base = requestScheme(r, cfg.TrustProxy) + "://" + r.Host
-	}
-	base = strings.TrimRight(base, "/")
+	base := cfg.publicBase(r)
 	w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+base+`/.well-known/oauth-protected-resource"`)
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -55,6 +55,7 @@ func Middleware(cfg Config, dbClient *db.Client, next http.Handler) http.Handler
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := bearerToken(r)
 		if token == "" {
+			setWWWAuthenticate(w, r, cfg)
 			http.Error(w, "missing authorization token", http.StatusUnauthorized)
 			return
 		}
@@ -63,6 +64,7 @@ func Middleware(cfg Config, dbClient *db.Client, next http.Handler) http.Handler
 
 		userID, newToken, err := resolveToken(ctx, cfg, dbClient, token)
 		if err != nil {
+			setWWWAuthenticate(w, r, cfg)
 			http.Error(w, "invalid or expired token", http.StatusUnauthorized)
 			return
 		}
@@ -263,4 +265,16 @@ func validSignatureUserID(secret []byte, token string) (string, error) {
 		return "", ErrInvalidToken
 	}
 	return claims.UserID, nil
+}
+
+// setWWWAuthenticate writes the WWW-Authenticate header required by RFC 9728
+// (OAuth 2.0 Protected Resource Metadata). Claude Code's MCP SDK reads the
+// resource_metadata URL to discover the authorization server before starting OAuth.
+func setWWWAuthenticate(w http.ResponseWriter, r *http.Request, cfg Config) {
+	base := cfg.PublicBaseURL
+	if base == "" {
+		base = requestScheme(r, cfg.TrustProxy) + "://" + r.Host
+	}
+	base = strings.TrimRight(base, "/")
+	w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+base+`/.well-known/oauth-protected-resource"`)
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -71,6 +71,45 @@ func TestMiddlewareInvalidToken(t *testing.T) {
 	}
 }
 
+func TestMiddlewareWWWAuthenticateOnMissingToken(t *testing.T) {
+	cfg := testMiddlewareCfg()
+	cfg.PublicBaseURL = "https://example.com"
+	h := auth.Middleware(cfg, nil, http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d want 401", w.Code)
+	}
+	got := w.Header().Get("WWW-Authenticate")
+	want := `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"`
+	if got != want {
+		t.Errorf("WWW-Authenticate: got %q want %q", got, want)
+	}
+}
+
+func TestMiddlewareWWWAuthenticateOnBadToken(t *testing.T) {
+	cfg := testMiddlewareCfg()
+	cfg.PublicBaseURL = "https://example.com"
+	h := auth.Middleware(cfg, nil, http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer garbage")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d want 401", w.Code)
+	}
+	got := w.Header().Get("WWW-Authenticate")
+	want := `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"`
+	if got != want {
+		t.Errorf("WWW-Authenticate: got %q want %q", got, want)
+	}
+}
+
 func TestMiddlewareTamperedToken(t *testing.T) {
 	token, err := auth.IssueAccessToken(testSecret, "user-1")
 	if err != nil {


### PR DESCRIPTION
## Root cause

Claude Code's MCP OAuth SDK follows RFC 9728 (OAuth 2.0 Protected Resource Metadata): when it gets a 401 from the MCP endpoint, it looks for a `WWW-Authenticate` header to find the authorization server. Without that header it has no idea where to start OAuth and silently fails with "SDK auth failed" — the Authenticate button in `/mcp` does nothing and the `mcp__notoriousmcp__authenticate` tool also fails.

## Changes

- **`GET /.well-known/oauth-protected-resource`** — new endpoint (RFC 9728) that returns a JSON document with `resource` and `authorization_servers` pointing to the CloudFront base URL
- **`WWW-Authenticate` header** — both 401 paths in `auth.Middleware` (missing token and invalid/expired token) now include `Bearer resource_metadata="<base>/.well-known/oauth-protected-resource"`
- **Two unit tests** verifying the header is present and correct on both 401 paths

## Test plan

- [x] `go test ./...` passes
- [ ] After deploy: open `/mcp` in Claude Code → click Authenticate → browser opens Google OAuth → complete flow → server shows connected
- [ ] Call a NoteoriousMCP tool to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)