### PR TITLE
fix: restore WWW-Authenticate header stripped by CloudFront

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -30,6 +30,11 @@ resource "aws_cloudfront_distribution" "main" {
 
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
     origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.restore_www_authenticate.arn
+    }
   }
 
   viewer_certificate {

--- a/terraform/cloudfront_function.tf
+++ b/terraform/cloudfront_function.tf
@@ -1,0 +1,18 @@
+resource "aws_cloudfront_function" "restore_www_authenticate" {
+  name    = "notoriousmcp-restore-www-authenticate"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  comment = "Restore WWW-Authenticate header stripped by CloudFront Lambda origin handling"
+
+  code = <<-EOF
+    async function handler(event) {
+      const response = event.response;
+      const headers = response.headers;
+      if (headers["x-amzn-remapped-www-authenticate"]) {
+        headers["www-authenticate"] = { value: headers["x-amzn-remapped-www-authenticate"].value };
+        delete headers["x-amzn-remapped-www-authenticate"];
+      }
+      return response;
+    }
+  EOF
+}


### PR DESCRIPTION
## Problem

CloudFront remaps `WWW-Authenticate` from Lambda origins to `x-amzn-remapped-www-authenticate` — a hard AWS behavior for headers that conflict with CloudFront's own auth mechanisms. The header never reaches the client, so Claude Code's MCP OAuth SDK gets a bare 401 with no auth challenge and silently fails.

Confirmed via `curl -si`: the header is present in Lambda's response but arrives at the client as `x-amzn-remapped-www-authenticate`.

## Fix

A CloudFront Function on the `viewer-response` event that copies `x-amzn-remapped-www-authenticate` back to `www-authenticate` before the response leaves CloudFront. The Lambda code stays correct; the fix lives at the edge where the problem occurs.

## Test plan

- [ ] After deploy: `curl -si -X POST https://d2eudgpkavi25i.cloudfront.net/mcp -H "Content-Type: application/json" -d '{}'` shows `www-authenticate: Bearer resource_metadata="..."` in the response headers
- [ ] Re-add MCP server and complete OAuth flow in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)