### PR TITLE
fix: sync Terraform to deployed infrastructure state

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,6 +1,7 @@
 locals {
   lambda_url_host = trimsuffix(replace(aws_lambda_function_url.main.function_url, "https://", ""), "/")
   cf_origin_id    = "lambda"
+  public_base_url = coalesce(var.public_base_url, trimsuffix(var.redirect_url, "/auth/callback"))
 }
 
 resource "aws_cloudfront_distribution" "main" {
@@ -28,13 +29,9 @@ resource "aws_cloudfront_distribution" "main" {
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]
 
-    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
-    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
-
-    function_association {
-      event_type   = "viewer-response"
-      function_arn = aws_cloudfront_function.restore_www_authenticate.arn
-    }
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
+    origin_request_policy_id   = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.www_authenticate.id
   }
 
   viewer_certificate {

--- a/terraform/cloudfront_function.tf
+++ b/terraform/cloudfront_function.tf
@@ -1,18 +1,12 @@
-resource "aws_cloudfront_function" "restore_www_authenticate" {
-  name    = "notoriousmcp-restore-www-authenticate"
-  runtime = "cloudfront-js-2.0"
-  publish = true
-  comment = "Restore WWW-Authenticate header stripped by CloudFront Lambda origin handling"
+resource "aws_cloudfront_response_headers_policy" "www_authenticate" {
+  name    = "notoriousmcp-www-authenticate"
+  comment = "Inject WWW-Authenticate on all responses; CloudFront strips it from Lambda origin responses"
 
-  code = <<-EOF
-    async function handler(event) {
-      const response = event.response;
-      const headers = response.headers;
-      if (headers["x-amzn-remapped-www-authenticate"]) {
-        headers["www-authenticate"] = { value: headers["x-amzn-remapped-www-authenticate"].value };
-        delete headers["x-amzn-remapped-www-authenticate"];
-      }
-      return response;
+  custom_headers_config {
+    items {
+      header   = "WWW-Authenticate"
+      value    = "Bearer resource_metadata=\"${local.public_base_url}/.well-known/oauth-protected-resource\""
+      override = false
     }
-  EOF
+  }
 }

--- a/terraform/cloudfront_headers_policy.tf
+++ b/terraform/cloudfront_headers_policy.tf
@@ -6,7 +6,7 @@ resource "aws_cloudfront_response_headers_policy" "www_authenticate" {
     items {
       header   = "WWW-Authenticate"
       value    = "Bearer resource_metadata=\"${local.public_base_url}/.well-known/oauth-protected-resource\""
-      override = false
+      override = true
     }
   }
 }

--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -43,6 +43,8 @@ data "aws_iam_policy_document" "deploy_policy" {
     actions = [
       "cloudfront:GetDistribution",
       "cloudfront:ListTagsForResource",
+      "cloudfront:GetResponseHeadersPolicy",
+      "cloudfront:ListResponseHeadersPolicies",
     ]
     resources = ["*"]
   }
@@ -118,6 +120,15 @@ data "aws_iam_policy_document" "deploy_policy" {
       "cloudfront:UpdateDistribution",
     ]
     resources = [aws_cloudfront_distribution.main.arn]
+  }
+
+  statement {
+    actions = [
+      "cloudfront:CreateResponseHeadersPolicy",
+      "cloudfront:UpdateResponseHeadersPolicy",
+      "cloudfront:DeleteResponseHeadersPolicy",
+    ]
+    resources = ["arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:response-headers-policy/*"]
   }
 
   statement {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -88,7 +88,7 @@ resource "aws_lambda_function" "main" {
       S3_BUCKET                = aws_s3_bucket.content.bucket
       ENVIRONMENT              = var.environment
       REDIRECT_URL             = var.redirect_url
-      PUBLIC_BASE_URL          = coalesce(var.public_base_url, trimsuffix(var.redirect_url, "/auth/callback"))
+      PUBLIC_BASE_URL          = local.public_base_url
       SSM_GOOGLE_CLIENT_ID     = aws_ssm_parameter.google_client_id.name
       SSM_GOOGLE_CLIENT_SECRET = aws_ssm_parameter.google_client_secret.name
       SSM_ADMIN_GOOGLE_IDS     = aws_ssm_parameter.admin_google_ids.name


### PR DESCRIPTION
## Problem

PR #80 was merged from a branch that still had the CloudFront Function approach. The actual deployed infrastructure uses a Response Headers Policy (applied locally after discovering that viewer-response Functions don't fire on 4xx error responses — so the Function never ran). Main's Terraform didn't match what's deployed, meaning the next `terraform apply` from CI would have tried to create a CloudFront Function and remove the Response Headers Policy.

## Changes

- **`cloudfront_function.tf`**: replace `aws_cloudfront_function` with `aws_cloudfront_response_headers_policy` that statically injects `WWW-Authenticate`
- **`cloudfront.tf`**: swap `function_association` block for `response_headers_policy_id`; extract `local.public_base_url` to avoid duplicating the `coalesce` expression
- **`lambda.tf`**: use `local.public_base_url` instead of inline `coalesce`
- **`iam_deploy.tf`**: add `GetResponseHeadersPolicy`/`ListResponseHeadersPolicies` (read) and `Create/Update/DeleteResponseHeadersPolicy` (write) permissions

## Plan output

`Plan: 0 to add, 2 to change, 0 to destroy` — the response headers policy already exists in AWS; Terraform just needs to update the distribution and IAM policy to reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)