### PR TITLE
feat: implement PKCE (RFC 7636)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Then open `/mcp` in Claude Code, select **notoriousmcp → Authenticate**, and c
 
 ### Other MCP clients
 
-Any MCP client that supports RFC 7591 dynamic client registration and OAuth 2.0 authorization code flow can connect. Point it at:
+Any MCP client that supports RFC 7591 dynamic client registration, PKCE (RFC 7636, S256 only), and OAuth 2.0 authorization code flow can connect. Point it at:
 
 - **MCP endpoint:** `https://<your-cloudfront-domain>/mcp`
 - **Auth server discovery:** `https://<your-cloudfront-domain>/.well-known/oauth-authorization-server`

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -90,12 +91,13 @@ func requestScheme(r *http.Request, trustProxy bool) string {
 func (h *Handler) wellKnown(w http.ResponseWriter, r *http.Request) {
 	base := h.cfg.publicBase(r)
 	meta := map[string]any{
-		"issuer":                   base,
-		"authorization_endpoint":   base + "/auth/login",
-		"token_endpoint":           base + "/auth/token",
-		"registration_endpoint":    base + "/register",
-		"response_types_supported": []string{"code"},
-		"grant_types_supported":    []string{"authorization_code"},
+		"issuer":                            base,
+		"authorization_endpoint":            base + "/auth/login",
+		"token_endpoint":                    base + "/auth/token",
+		"registration_endpoint":             base + "/register",
+		"response_types_supported":          []string{"code"},
+		"grant_types_supported":             []string{"authorization_code"},
+		"code_challenge_methods_supported":   []string{"S256"},
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(meta)
@@ -119,6 +121,7 @@ type oauthStatePayload struct {
 	Nonce             string `json:"n"`
 	ClientRedirectURI string `json:"r"`
 	ClientState       string `json:"s"`
+	CodeChallenge     string `json:"cc,omitempty"`
 }
 
 // login initiates the OAuth flow by redirecting to Google.
@@ -156,6 +159,15 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// PKCE (RFC 7636): if code_challenge is present, method must be S256.
+	codeChallenge := r.URL.Query().Get("code_challenge")
+	if codeChallenge != "" {
+		if r.URL.Query().Get("code_challenge_method") != "S256" {
+			http.Error(w, "unsupported code_challenge_method", http.StatusBadRequest)
+			return
+		}
+	}
+
 	nonce, err := generateRandomCode()
 	if err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -167,6 +179,7 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 		Nonce:             nonce,
 		ClientRedirectURI: clientRedirectURI,
 		ClientState:       r.URL.Query().Get("state"),
+		CodeChallenge:     codeChallenge,
 	}
 	stateJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -180,8 +193,6 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 	// Note: oauthStatePayload (redirect_uri + client state) is base64-encoded, not
 	// encrypted — it is visible to the browser. It contains no secrets; the nonce is
 	// the only security-critical value and it is validated separately via this cookie.
-	// PKCE (RFC 7636) is not enforced here. If public/native MCP clients are supported
-	// in future, add PKCE via oauth2.S256ChallengeOption before deploying to them.
 	secure := requestScheme(r, h.cfg.TrustProxy) == "https"
 	http.SetCookie(w, &http.Cookie{
 		Name:     "oauth_nonce",
@@ -305,7 +316,11 @@ func (h *Handler) callback(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
-		if saveErr := h.db.SaveAuthCode(ctx, code, info.Sub, clientRedirectURI, authCodeTTL); saveErr == nil {
+		codeChallengeMethod := ""
+		if payload.CodeChallenge != "" {
+			codeChallengeMethod = "S256"
+		}
+		if saveErr := h.db.SaveAuthCode(ctx, code, info.Sub, clientRedirectURI, payload.CodeChallenge, codeChallengeMethod, authCodeTTL); saveErr == nil {
 			exchangeCode = code
 			break
 		} else if !errors.Is(saveErr, db.ErrAuthCodeCollision) {
@@ -515,6 +530,20 @@ func (h *Handler) token(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// RFC 7636: if the auth code was bound to a PKCE challenge, the verifier
+	// must be present and must produce the stored challenge when hashed.
+	if redeemed.CodeChallenge != "" {
+		verifier := r.FormValue("code_verifier")
+		if verifier == "" {
+			writeJSONError(w, http.StatusBadRequest, "invalid_grant")
+			return
+		}
+		if !verifyS256(verifier, redeemed.CodeChallenge) {
+			writeJSONError(w, http.StatusBadRequest, "invalid_grant")
+			return
+		}
+	}
+
 	accessToken, err := IssueAccessToken(h.cfg.TokenSecret, redeemed.UserID)
 	if err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -621,4 +650,12 @@ func (h *Handler) upsertUser(ctx context.Context, info *googleUserInfo, refreshT
 	}
 
 	return nil
+}
+
+// verifyS256 checks that SHA-256(verifier), base64url-encoded without padding,
+// equals the stored challenge — the RFC 7636 S256 method.
+func verifyS256(verifier, challenge string) bool {
+	h := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(h[:])
+	return computed == challenge
 }

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -2,6 +2,8 @@ package auth_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -587,7 +589,7 @@ func TestTokenEndpointRoundTrip(t *testing.T) {
 	userID := "user-" + randUID()
 	code := "code-" + randUID()
 	redirectURI := "https://example.com/auth/callback"
-	if err := dbClient.SaveAuthCode(context.Background(), code, userID, redirectURI, 60*time.Second); err != nil {
+	if err := dbClient.SaveAuthCode(context.Background(), code, userID, redirectURI, "", "", 60*time.Second); err != nil {
 		t.Fatalf("save auth code: %v", err)
 	}
 	// Code is redeemed (deleted) by the handler on success; cleanup is a no-op in the happy path
@@ -653,7 +655,7 @@ func TestTokenEndpointSingleUse(t *testing.T) {
 	userID := "user-" + randUID()
 	code := "code-" + randUID()
 	redirectURI := "https://example.com/auth/callback"
-	if err := dbClient.SaveAuthCode(context.Background(), code, userID, redirectURI, 60*time.Second); err != nil {
+	if err := dbClient.SaveAuthCode(context.Background(), code, userID, redirectURI, "", "", 60*time.Second); err != nil {
 		t.Fatalf("save auth code: %v", err)
 	}
 	t.Cleanup(func() { _, _ = dbClient.RedeemAuthCode(context.Background(), code) })
@@ -685,7 +687,7 @@ func TestTokenEndpointRedirectURIMismatch(t *testing.T) {
 
 	userID := "user-" + randUID()
 	code := "code-" + randUID()
-	if err := dbClient.SaveAuthCode(context.Background(), code, userID, "https://example.com/auth/callback", 60*time.Second); err != nil {
+	if err := dbClient.SaveAuthCode(context.Background(), code, userID, "https://example.com/auth/callback", "", "", 60*time.Second); err != nil {
 		t.Fatalf("save auth code: %v", err)
 	}
 	t.Cleanup(func() { _, _ = dbClient.RedeemAuthCode(context.Background(), code) })
@@ -717,7 +719,7 @@ func TestTokenEndpointRedirectURIOmitted(t *testing.T) {
 
 	userID := "user-" + randUID()
 	code := "code-" + randUID()
-	if err := dbClient.SaveAuthCode(context.Background(), code, userID, "https://example.com/auth/callback", 60*time.Second); err != nil {
+	if err := dbClient.SaveAuthCode(context.Background(), code, userID, "https://example.com/auth/callback", "", "", 60*time.Second); err != nil {
 		t.Fatalf("save auth code: %v", err)
 	}
 	t.Cleanup(func() { _, _ = dbClient.RedeemAuthCode(context.Background(), code) })
@@ -737,6 +739,104 @@ func TestTokenEndpointRedirectURIOmitted(t *testing.T) {
 	}
 	if body["error"] != "invalid_grant" {
 		t.Errorf("error: got %q want invalid_grant", body["error"])
+	}
+}
+
+func s256Challenge(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+func TestTokenEndpointPKCEValid(t *testing.T) {
+	dbClient := newTestDBClient(t)
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	userID := "user-" + randUID()
+	code := "code-" + randUID()
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	challenge := s256Challenge(verifier)
+
+	if err := dbClient.SaveAuthCode(context.Background(), code, userID, "https://example.com/auth/callback", challenge, "S256", 60*time.Second); err != nil {
+		t.Fatalf("save auth code: %v", err)
+	}
+	t.Cleanup(func() { _, _ = dbClient.RedeemAuthCode(context.Background(), code) })
+
+	body := strings.NewReader("grant_type=authorization_code&code=" + code + "&redirect_uri=https%3A%2F%2Fexample.com%2Fauth%2Fcallback&code_verifier=" + verifier)
+	req := httptest.NewRequest("POST", "/auth/token", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status: got %d want 200, body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTokenEndpointPKCEMissingVerifier(t *testing.T) {
+	dbClient := newTestDBClient(t)
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	userID := "user-" + randUID()
+	code := "code-" + randUID()
+	challenge := s256Challenge("some-verifier")
+
+	if err := dbClient.SaveAuthCode(context.Background(), code, userID, "https://example.com/auth/callback", challenge, "S256", 60*time.Second); err != nil {
+		t.Fatalf("save auth code: %v", err)
+	}
+	t.Cleanup(func() { _, _ = dbClient.RedeemAuthCode(context.Background(), code) })
+
+	body := strings.NewReader("grant_type=authorization_code&code=" + code + "&redirect_uri=https%3A%2F%2Fexample.com%2Fauth%2Fcallback")
+	req := httptest.NewRequest("POST", "/auth/token", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d want 400", w.Code)
+	}
+}
+
+func TestTokenEndpointPKCEWrongVerifier(t *testing.T) {
+	dbClient := newTestDBClient(t)
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	userID := "user-" + randUID()
+	code := "code-" + randUID()
+	challenge := s256Challenge("correct-verifier")
+
+	if err := dbClient.SaveAuthCode(context.Background(), code, userID, "https://example.com/auth/callback", challenge, "S256", 60*time.Second); err != nil {
+		t.Fatalf("save auth code: %v", err)
+	}
+	t.Cleanup(func() { _, _ = dbClient.RedeemAuthCode(context.Background(), code) })
+
+	body := strings.NewReader("grant_type=authorization_code&code=" + code + "&redirect_uri=https%3A%2F%2Fexample.com%2Fauth%2Fcallback&code_verifier=wrong-verifier")
+	req := httptest.NewRequest("POST", "/auth/token", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d want 400", w.Code)
+	}
+}
+
+func TestLoginRejectsUnknownCodeChallengeMethod(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/auth/login?code_challenge=abc&code_challenge_method=plain", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d want 400", w.Code)
 	}
 }
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -748,8 +748,7 @@ func s256Challenge(verifier string) string {
 }
 
 func TestTokenEndpointPKCEValid(t *testing.T) {
-	dbClient := newTestDBClient(t)
-	h := newTestHandler(t)
+	h, dbClient := newTestHandlerWithDB(t)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 
@@ -775,8 +774,7 @@ func TestTokenEndpointPKCEValid(t *testing.T) {
 }
 
 func TestTokenEndpointPKCEMissingVerifier(t *testing.T) {
-	dbClient := newTestDBClient(t)
-	h := newTestHandler(t)
+	h, dbClient := newTestHandlerWithDB(t)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 
@@ -801,8 +799,7 @@ func TestTokenEndpointPKCEMissingVerifier(t *testing.T) {
 }
 
 func TestTokenEndpointPKCEWrongVerifier(t *testing.T) {
-	dbClient := newTestDBClient(t)
-	h := newTestHandler(t)
+	h, dbClient := newTestHandlerWithDB(t)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 

--- a/internal/db/auth_codes.go
+++ b/internal/db/auth_codes.go
@@ -20,11 +20,13 @@ var (
 const authCodeSK = "AUTHCODE"
 
 type authCodeRecord struct {
-	PK          string `dynamodbav:"PK"`
-	SK          string `dynamodbav:"SK"`
-	UserID      string `dynamodbav:"UserID"`
-	RedirectURI string `dynamodbav:"RedirectURI"`
-	ExpiresAt   int64  `dynamodbav:"ExpiresAt"`
+	PK                  string `dynamodbav:"PK"`
+	SK                  string `dynamodbav:"SK"`
+	UserID              string `dynamodbav:"UserID"`
+	RedirectURI         string `dynamodbav:"RedirectURI"`
+	CodeChallenge       string `dynamodbav:"CodeChallenge,omitempty"`
+	CodeChallengeMethod string `dynamodbav:"CodeChallengeMethod,omitempty"`
+	ExpiresAt           int64  `dynamodbav:"ExpiresAt"`
 }
 
 func authCodePK(code string) string { return "AUTHCODE#" + code }
@@ -32,14 +34,18 @@ func authCodePK(code string) string { return "AUTHCODE#" + code }
 // SaveAuthCode stores a short-lived opaque exchange code mapped to a user ID.
 // redirectURI is the redirect_uri from the authorization request; callers must
 // pass a non-empty value — RedeemAuthCode rejects codes stored without one.
+// codeChallenge and codeChallengeMethod are the PKCE values from the authorization
+// request; pass empty strings for non-PKCE flows.
 // ExpiresAt is written as a Unix epoch integer for DynamoDB TTL compatibility.
-func (c *Client) SaveAuthCode(ctx context.Context, code, userID, redirectURI string, ttl time.Duration) error {
+func (c *Client) SaveAuthCode(ctx context.Context, code, userID, redirectURI, codeChallenge, codeChallengeMethod string, ttl time.Duration) error {
 	rec := authCodeRecord{
-		PK:          authCodePK(code),
-		SK:          authCodeSK,
-		UserID:      userID,
-		RedirectURI: redirectURI,
-		ExpiresAt:   time.Now().Add(ttl).Unix(),
+		PK:                  authCodePK(code),
+		SK:                  authCodeSK,
+		UserID:              userID,
+		RedirectURI:         redirectURI,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+		ExpiresAt:           time.Now().Add(ttl).Unix(),
 	}
 	item, err := attributevalue.MarshalMap(rec)
 	if err != nil {
@@ -62,8 +68,10 @@ func (c *Client) SaveAuthCode(ctx context.Context, code, userID, redirectURI str
 
 // RedeemedAuthCode holds the values recovered when an exchange code is redeemed.
 type RedeemedAuthCode struct {
-	UserID      string
-	RedirectURI string // empty if none was bound at save time
+	UserID              string
+	RedirectURI         string // empty if none was bound at save time
+	CodeChallenge       string // empty for non-PKCE flows
+	CodeChallengeMethod string // empty for non-PKCE flows
 }
 
 // RedeemAuthCode atomically deletes the code and returns the associated values.
@@ -96,5 +104,10 @@ func (c *Client) RedeemAuthCode(ctx context.Context, code string) (RedeemedAuthC
 		return RedeemedAuthCode{}, ErrAuthCodeNotFound
 	}
 
-	return RedeemedAuthCode{UserID: rec.UserID, RedirectURI: rec.RedirectURI}, nil
+	return RedeemedAuthCode{
+		UserID:              rec.UserID,
+		RedirectURI:         rec.RedirectURI,
+		CodeChallenge:       rec.CodeChallenge,
+		CodeChallengeMethod: rec.CodeChallengeMethod,
+	}, nil
 }

--- a/internal/db/auth_codes_test.go
+++ b/internal/db/auth_codes_test.go
@@ -17,7 +17,7 @@ func TestAuthCodeRoundTrip(t *testing.T) {
 	userID := "user-" + uid()
 
 	redirectURI := "https://example.com/callback"
-	if err := c.SaveAuthCode(ctx, code, userID, redirectURI, 60*time.Second); err != nil {
+	if err := c.SaveAuthCode(ctx, code, userID, redirectURI, "", "", 60*time.Second); err != nil {
 		t.Fatalf("save auth code: %v", err)
 	}
 
@@ -40,7 +40,7 @@ func TestAuthCodeSingleUse(t *testing.T) {
 	code := "testcode-" + uid()
 	userID := "user-" + uid()
 
-	if err := c.SaveAuthCode(ctx, code, userID, "", 60*time.Second); err != nil {
+	if err := c.SaveAuthCode(ctx, code, userID, "", "", "", 60*time.Second); err != nil {
 		t.Fatalf("save auth code: %v", err)
 	}
 	if _, err := c.RedeemAuthCode(ctx, code); err != nil {
@@ -70,10 +70,10 @@ func TestAuthCodeCollision(t *testing.T) {
 	code := "testcode-" + uid()
 	userID := "user-" + uid()
 
-	if err := c.SaveAuthCode(ctx, code, userID, "", 60*time.Second); err != nil {
+	if err := c.SaveAuthCode(ctx, code, userID, "", "", "", 60*time.Second); err != nil {
 		t.Fatalf("first save: %v", err)
 	}
-	err := c.SaveAuthCode(ctx, code, userID, "", 60*time.Second)
+	err := c.SaveAuthCode(ctx, code, userID, "", "", "", 60*time.Second)
 	if !errors.Is(err, db.ErrAuthCodeCollision) {
 		t.Errorf("duplicate save: got %v want ErrAuthCodeCollision", err)
 	}
@@ -87,7 +87,7 @@ func TestAuthCodeExpired(t *testing.T) {
 	userID := "user-" + uid()
 
 	// Save with a TTL already in the past.
-	if err := c.SaveAuthCode(ctx, code, userID, "", -1*time.Second); err != nil {
+	if err := c.SaveAuthCode(ctx, code, userID, "", "", "", -1*time.Second); err != nil {
 		t.Fatalf("save expired auth code: %v", err)
 	}
 


### PR DESCRIPTION
Closes #83.

## Problem

Claude Code's MCP OAuth SDK requires PKCE (RFC 7636). It sends `code_challenge` + `code_challenge_method=S256` in the authorization request and `code_verifier` at token exchange. Without server-side PKCE support the SDK silently failed with "SDK auth failed" before ever opening a browser — the root cause of the broken OAuth flow.

The `/register` handler comment even said "Claude Code uses PKCE (public client flow)" but it was never implemented.

## Changes

- **`internal/db`**: `authCodeRecord` gains `CodeChallenge`/`CodeChallengeMethod` fields; `SaveAuthCode` signature updated to accept them; `RedeemedAuthCode` returns them. Existing callers pass empty strings (non-PKCE flows still work).
- **`/auth/login`**: validates `code_challenge_method` is `S256` when a challenge is present (rejects `plain` and anything else); stores the challenge in the state payload so it survives the Google redirect.
- **`/auth/callback`**: passes the stored challenge through to `SaveAuthCode`.
- **`/auth/token`**: validates `code_verifier` against the stored challenge using SHA-256 (base64url, no padding); rejects missing or incorrect verifier with `invalid_grant`.
- **`/.well-known/oauth-authorization-server`**: now includes `code_challenge_methods_supported: ["S256"]`.

## Tests

Four new PKCE-specific test cases:
- Valid verifier → 200
- Missing verifier when code was PKCE-bound → 400
- Wrong verifier → 400
- Unsupported `code_challenge_method` at `/auth/login` → 400

## Test plan

- [ ] CI passes
- [ ] After deploy: re-add MCP server, open `/mcp` → Authenticate → browser opens → complete Google OAuth → server shows connected
- [ ] Call a NoteoriousMCP tool to confirm tools are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)