### PR TITLE
fix: use CloudFront Function to conditionally restore WWW-Authenticate

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -29,9 +29,13 @@ resource "aws_cloudfront_distribution" "main" {
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]
 
-    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
-    origin_request_policy_id   = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.www_authenticate.id
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
+
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.restore_www_authenticate.arn
+    }
   }
 
   viewer_certificate {

--- a/terraform/cloudfront_headers_policy.tf
+++ b/terraform/cloudfront_headers_policy.tf
@@ -1,12 +1,18 @@
-resource "aws_cloudfront_response_headers_policy" "www_authenticate" {
-  name    = "notoriousmcp-www-authenticate"
-  comment = "Inject WWW-Authenticate on all responses; CloudFront strips it from Lambda origin responses"
+resource "aws_cloudfront_function" "restore_www_authenticate" {
+  name    = "notoriousmcp-restore-www-authenticate"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  comment = "Restore WWW-Authenticate from x-amzn-remapped-www-authenticate on responses that have it"
 
-  custom_headers_config {
-    items {
-      header   = "WWW-Authenticate"
-      value    = "Bearer resource_metadata=\"${local.public_base_url}/.well-known/oauth-protected-resource\""
-      override = true
+  code = <<-EOF
+    async function handler(event) {
+      const response = event.response;
+      const headers = response.headers;
+      if (headers["x-amzn-remapped-www-authenticate"]) {
+        headers["www-authenticate"] = { value: headers["x-amzn-remapped-www-authenticate"].value };
+        delete headers["x-amzn-remapped-www-authenticate"];
+      }
+      return response;
     }
-  }
+  EOF
 }

--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -43,8 +43,9 @@ data "aws_iam_policy_document" "deploy_policy" {
     actions = [
       "cloudfront:GetDistribution",
       "cloudfront:ListTagsForResource",
-      "cloudfront:GetResponseHeadersPolicy",
-      "cloudfront:ListResponseHeadersPolicies",
+      "cloudfront:GetFunction",
+      "cloudfront:DescribeFunction",
+      "cloudfront:ListFunctions",
     ]
     resources = ["*"]
   }
@@ -124,11 +125,12 @@ data "aws_iam_policy_document" "deploy_policy" {
 
   statement {
     actions = [
-      "cloudfront:CreateResponseHeadersPolicy",
-      "cloudfront:UpdateResponseHeadersPolicy",
-      "cloudfront:DeleteResponseHeadersPolicy",
+      "cloudfront:CreateFunction",
+      "cloudfront:UpdateFunction",
+      "cloudfront:DeleteFunction",
+      "cloudfront:PublishFunction",
     ]
-    resources = ["arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:response-headers-policy/*"]
+    resources = ["arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:function/notoriousmcp-*"]
   }
 
   statement {


### PR DESCRIPTION
## Summary

- Replaces the Response Headers Policy (which injected `WWW-Authenticate` on **all** responses) with a CloudFront viewer-response Function
- The Function checks for `x-amzn-remapped-www-authenticate` (CloudFront's remapped name for the header) and restores it as `www-authenticate` only when present — i.e. only on 401 responses from the Lambda
- Public 200 responses (discovery endpoints) no longer get a spurious `WWW-Authenticate` header, which was causing the Claude Code SDK to mark the server as "Failed to connect" instead of "Needs authentication"

## Root cause

The SDK sees `WWW-Authenticate` on a 200 response from `/.well-known/oauth-authorization-server` and treats it as an error, skipping the OAuth flow entirely.

## Test plan

- [ ] Deploy and wait for CloudFront `Status: Deployed`
- [ ] `curl -si https://d2eudgpkavi25i.cloudfront.net/mcp` → expect `www-authenticate` on 401, **not** on 200s
- [ ] `curl -si https://d2eudgpkavi25i.cloudfront.net/.well-known/oauth-authorization-server` → expect 200 with **no** `www-authenticate`
- [ ] `claude mcp list` → notoriousmcp shows "Needs authentication" instead of "Failed to connect"
- [ ] `/mcp` → Authenticate → complete Google OAuth → tools visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)