### PR TITLE
test: debug CF Function header visibility on 401

### DIFF
--- a/terraform/cloudfront_headers_policy.tf
+++ b/terraform/cloudfront_headers_policy.tf
@@ -8,6 +8,8 @@ resource "aws_cloudfront_function" "restore_www_authenticate" {
     async function handler(event) {
       const response = event.response;
       const headers = response.headers;
+      headers["x-cf-function-ran"] = { value: "yes" };
+      headers["x-cf-header-keys"] = { value: Object.keys(headers).join(",") };
       if (headers["x-amzn-remapped-www-authenticate"]) {
         headers["www-authenticate"] = { value: headers["x-amzn-remapped-www-authenticate"].value };
         delete headers["x-amzn-remapped-www-authenticate"];


### PR DESCRIPTION
Temporary debug PR — adds x-cf-function-ran and x-cf-header-keys headers unconditionally to confirm the viewer-response Function fires on 401 responses. Will revert after confirming.