### PR TITLE
fix: accept any path in loopback redirect URI (Claude Code OAuth compat)

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -351,11 +351,10 @@ func (h *Handler) callback(w http.ResponseWriter, r *http.Request) {
 //  1. Exact match against the server's configured redirect URL (scheme, host,
 //     path, no query string). path.Clean neutralises traversal sequences.
 //
-//  2. http://127.0.0.1:<port>/callback — the loopback redirect form used by
-//     native/CLI OAuth clients (RFC 8252 §7.3). Any port is accepted; the path
-//     must be exactly "/callback". This lets MCP clients (e.g. Claude Code with
-//     --callback-port) register a fixed localhost port without needing a separate
-//     configured redirect URL for each client.
+//  2. http://127.0.0.1:<port>/<any-path> — the loopback redirect form used by
+//     native/CLI OAuth clients (RFC 8252 §7.3). Any port and any path is
+//     accepted. RFC 8252 §7.3 only requires the loopback IP; different MCP
+//     clients use different paths (e.g. Claude Code uses /oauth/code/callback).
 //
 // Query strings are rejected on the client URI because they are not part of a
 // valid callback URL and could be used to smuggle state via an open redirector.
@@ -368,8 +367,8 @@ func ValidateRedirectURI(configuredRedirectURL, clientRedirectURI string) error 
 		return fmt.Errorf("redirect_uri must not contain a query string")
 	}
 
-	// Loopback form: http://127.0.0.1:<port>/callback
-	if client.Scheme == "http" && client.Hostname() == "127.0.0.1" && path.Clean(client.Path) == "/callback" {
+	// Loopback form: http://127.0.0.1:<port>/<path>
+	if client.Scheme == "http" && client.Hostname() == "127.0.0.1" {
 		if client.Port() == "" {
 			return fmt.Errorf("redirect_uri loopback form requires an explicit port")
 		}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -95,14 +95,16 @@ func TestValidateRedirectURI(t *testing.T) {
 		// Query string on client URI — rejected (RFC 6749 requires exact match, no query).
 		{"query string", "https://notoriousmcp.com/auth/callback?foo=bar", true},
 
-		// Loopback form (RFC 8252 §7.3) — any port, must be http://127.0.0.1.
+		// Loopback form (RFC 8252 §7.3) — any port and path, must be http://127.0.0.1.
 		{"loopback port 54321", "http://127.0.0.1:54321/callback", false},
 		{"loopback port 8080", "http://127.0.0.1:8080/callback", false},
 		{"loopback port 1", "http://127.0.0.1:1/callback", false},
+		// Claude Code uses /oauth/code/callback — allowed.
+		{"loopback claude code path", "http://127.0.0.1:54321/oauth/code/callback", false},
+		// Any path is allowed for loopback clients (RFC 8252 §7.3).
+		{"loopback any path", "http://127.0.0.1:54321/other", false},
 		// Loopback without explicit port — rejected.
 		{"loopback no port", "http://127.0.0.1/callback", true},
-		// Wrong path on loopback — rejected.
-		{"loopback wrong path", "http://127.0.0.1:54321/other", true},
 		// Non-127.0.0.1 loopback addresses — rejected (not in Google's allowlist).
 		{"loopback ipv6", "http://[::1]:54321/callback", true},
 		{"localhost hostname", "http://localhost:54321/callback", true},


### PR DESCRIPTION
## Summary

- Claude Code uses `http://127.0.0.1:<port>/oauth/code/callback` as its OAuth redirect URI during dynamic client registration, but the server required the path to be exactly `/callback`
- This caused `claude mcp list` to show `notoriousmcp: ✗ Failed to connect` (dynamic client registration fails → no OAuth flow starts) instead of `! Needs authentication`
- RFC 8252 §7.3 only requires the loopback IP address for native/CLI OAuth clients; the path is implementation-defined
- Fix: remove the path restriction in `ValidateRedirectURI` so any path is accepted for `http://127.0.0.1:<port>` URIs

## Test plan

- [x] `TestValidateRedirectURI` updated: `loopback_any_path` and `loopback_claude_code_path` now pass; old `loopback_wrong_path` (which expected rejection) removed
- [x] Full test suite passes (`go test ./...`)
- [ ] After deploy: `claude mcp list` should show `! Needs authentication` and `/mcp` auth dialog should complete Google OAuth successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)