### PR TITLE
fix: set resource field to /mcp endpoint URL in protected resource metadata

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -109,7 +109,7 @@ func (h *Handler) wellKnown(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) protectedResource(w http.ResponseWriter, r *http.Request) {
 	base := h.cfg.publicBase(r)
 	meta := map[string]any{
-		"resource":               base,
+		"resource":               base + "/mcp",
 		"authorization_servers": []string{base},
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -66,6 +66,37 @@ func TestWellKnown(t *testing.T) {
 	}
 }
 
+func TestProtectedResource(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type: got %q want application/json", ct)
+	}
+
+	var meta map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&meta); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// resource must exactly match the MCP endpoint URL (Claude Code validates this).
+	if meta["resource"] != "http://example.com/mcp" {
+		t.Errorf("resource: got %v want http://example.com/mcp", meta["resource"])
+	}
+	as, _ := meta["authorization_servers"].([]any)
+	if len(as) != 1 || as[0] != "http://example.com" {
+		t.Errorf("authorization_servers: got %v want [http://example.com]", meta["authorization_servers"])
+	}
+}
+
 func TestWellKnownXForwardedProto(t *testing.T) {
 	h := newTestHandler(t)
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Summary

- Claude Code validates that the `resource` field in the OAuth protected resource metadata (RFC 9728) exactly matches the MCP endpoint URL — in this case `https://drm85valm1.execute-api.us-west-2.amazonaws.com/mcp`
- The server was returning `"resource": "https://drm85valm1.execute-api.us-west-2.amazonaws.com"` (no `/mcp` suffix), causing a resource mismatch
- This made Claude Code report `✗ Failed to connect` and skip the OAuth flow entirely, so the server never appeared in the `/mcp` auth dialog
- Fix: append `/mcp` to the `resource` field value to match the actual MCP endpoint

## Root cause discovery

Extracted from Claude Code binary: `PRM resource mismatch: expected <url>, got <url>` — confirms it does a strict equality check between `resource` and the endpoint URL.

## Test plan

- [x] Full test suite passes (`go test ./...`)
- [ ] After deploy: `claude mcp list` should show `! Needs authentication` and the `/mcp` dialog should show notoriousmcp for authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)