### PR TITLE
fix: accept localhost as loopback redirect URI hostname

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -351,10 +351,11 @@ func (h *Handler) callback(w http.ResponseWriter, r *http.Request) {
 //  1. Exact match against the server's configured redirect URL (scheme, host,
 //     path, no query string). path.Clean neutralises traversal sequences.
 //
-//  2. http://127.0.0.1:<port>/<any-path> — the loopback redirect form used by
-//     native/CLI OAuth clients (RFC 8252 §7.3). Any port and any path is
-//     accepted. RFC 8252 §7.3 only requires the loopback IP; different MCP
-//     clients use different paths (e.g. Claude Code uses /oauth/code/callback).
+//  2. http://127.0.0.1:<port>/<any-path> or http://localhost:<port>/<any-path>
+//     — the loopback redirect form used by native/CLI OAuth clients (RFC 8252
+//     §7.3). Any port and any path is accepted. Both "127.0.0.1" and "localhost"
+//     are accepted because Claude Code's MCP SDK uses "localhost" (despite RFC
+//     8252 §8.3 recommending the IP literal).
 //
 // Query strings are rejected on the client URI because they are not part of a
 // valid callback URL and could be used to smuggle state via an open redirector.
@@ -367,8 +368,8 @@ func ValidateRedirectURI(configuredRedirectURL, clientRedirectURI string) error 
 		return fmt.Errorf("redirect_uri must not contain a query string")
 	}
 
-	// Loopback form: http://127.0.0.1:<port>/<path>
-	if client.Scheme == "http" && client.Hostname() == "127.0.0.1" {
+	// Loopback form: http://127.0.0.1:<port>/<path> or http://localhost:<port>/<path>
+	if client.Scheme == "http" && (client.Hostname() == "127.0.0.1" || client.Hostname() == "localhost") {
 		if client.Port() == "" {
 			return fmt.Errorf("redirect_uri loopback form requires an explicit port")
 		}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -95,21 +95,23 @@ func TestValidateRedirectURI(t *testing.T) {
 		// Query string on client URI — rejected (RFC 6749 requires exact match, no query).
 		{"query string", "https://notoriousmcp.com/auth/callback?foo=bar", true},
 
-		// Loopback form (RFC 8252 §7.3) — any port and path, must be http://127.0.0.1.
+		// Loopback form (RFC 8252 §7.3) — any port and path; 127.0.0.1 or localhost.
 		{"loopback port 54321", "http://127.0.0.1:54321/callback", false},
 		{"loopback port 8080", "http://127.0.0.1:8080/callback", false},
 		{"loopback port 1", "http://127.0.0.1:1/callback", false},
-		// Claude Code uses /oauth/code/callback — allowed.
-		{"loopback claude code path", "http://127.0.0.1:54321/oauth/code/callback", false},
 		// Any path is allowed for loopback clients (RFC 8252 §7.3).
 		{"loopback any path", "http://127.0.0.1:54321/other", false},
+		// localhost hostname accepted — Claude Code uses http://localhost:<port>/callback.
+		{"localhost callback", "http://localhost:54321/callback", false},
+		{"localhost any path", "http://localhost:54321/oauth/code/callback", false},
 		// Loopback without explicit port — rejected.
 		{"loopback no port", "http://127.0.0.1/callback", true},
-		// Non-127.0.0.1 loopback addresses — rejected (not in Google's allowlist).
+		{"localhost no port", "http://localhost/callback", true},
+		// IPv6 loopback addresses — rejected (not in Google's allowlist).
 		{"loopback ipv6", "http://[::1]:54321/callback", true},
-		{"localhost hostname", "http://localhost:54321/callback", true},
 		// HTTPS loopback — rejected (Google only registers http://127.0.0.1).
 		{"loopback https", "https://127.0.0.1:54321/callback", true},
+		{"localhost https", "https://localhost:54321/callback", true},
 		// Loopback with query string — rejected.
 		{"loopback query string", "http://127.0.0.1:54321/callback?foo=bar", true},
 	}


### PR DESCRIPTION
## Root cause

Claude Code's MCP SDK uses `http://localhost:<port>/callback` as its OAuth redirect URI. Our `/register` endpoint rejected this with `400 invalid_redirect_uri` because `ValidateRedirectURI` only accepted `127.0.0.1` as the loopback hostname.

When Claude Code received the 400, it parsed the body as an RFC 6749 OAuth error response (`ic9`) and threw a `server_error` exception (`Et`). The MCP transport's error handler only routes `tR || code===401 || code===403` to the "needs auth" path — so this `Et` exception fell through to the generic "failed" path, and the server appeared as `✗ Failed to connect` instead of `! Needs authentication` and never showed up in the `/mcp` dialog.

## Diagnosis source

`~/Library/Caches/claude-cli-nodejs/-Users-jimmy-claude/mcp-logs-notoriousmcp/` showed the actual flow:

```
"Returning cached discovery state (authServer: https://...)"
"Saving discovery state ..."
"No client info found"        ← triggers dynamic client registration
"HTTP Connection failed after 321ms"
error: "Et\n    at ic9 ...\n    at K_5 ...\n    at N\$8 ...\n    at qg ..."
```

`K_5` is the dynamic client registration function; `ic9` parses OAuth error responses. The earlier guess that Claude Code uses `/oauth/code/callback` came from a different OAuth library bundled in the binary, not the MCP SDK itself.

## Fix

`ValidateRedirectURI` now accepts both `127.0.0.1` and `localhost` as loopback hostnames. All other constraints (http scheme, explicit port, no query string) preserved.

## Test plan

- [x] `TestValidateRedirectURI` adds `localhost callback`, `localhost any path`, `localhost no port`, `localhost https` cases
- [x] Full test suite passes (`go test ./...`)
- [ ] After deploy: `claude mcp list` shows `! Needs authentication` and `/mcp` dialog includes notoriousmcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)