### PR TITLE
fix: use API Gateway v2 event types so cookies survive the Lambda adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 # Binaries
 bin/
 *.exe
-bootstrap
-lambda.zip
-server
+/bootstrap
+/lambda.zip
+/server
 
 # Environment
 .env

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,7 +27,9 @@ import (
 
 var handler http.Handler
 
-func init() {
+// initHandler builds the global handler from environment + SSM. Invoked from main
+// so tests can swap the handler without triggering AWS config loading.
+func initHandler() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -86,11 +88,11 @@ func init() {
 	handler = publicRouter(mux, protected)
 }
 
-func lambdaHandler(ctx context.Context, req events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
+func lambdaHandler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 	httpReq, err := toHTTPRequest(ctx, req)
 	if err != nil {
 		log.Printf("toHTTPRequest: %v", err)
-		return events.LambdaFunctionURLResponse{
+		return events.APIGatewayV2HTTPResponse{
 			StatusCode: 400,
 			Headers:    map[string]string{"Content-Type": "application/json"},
 			Body:       `{"error":"bad request"}`,
@@ -101,8 +103,14 @@ func lambdaHandler(ctx context.Context, req events.LambdaFunctionURLRequest) (ev
 	handler.ServeHTTP(rec, httpReq)
 
 	resp := rec.Result()
+	// API Gateway v2 requires Set-Cookie values in a dedicated Cookies array;
+	// collapsing them into a comma-joined Headers entry produces a single malformed cookie.
+	setCookies := resp.Header.Values("Set-Cookie")
 	headers := make(map[string]string, len(resp.Header))
 	for k, vs := range resp.Header {
+		if http.CanonicalHeaderKey(k) == "Set-Cookie" {
+			continue
+		}
 		headers[k] = strings.Join(vs, ", ")
 	}
 
@@ -114,19 +122,21 @@ func lambdaHandler(ctx context.Context, req events.LambdaFunctionURLRequest) (ev
 		isBase64 = true
 	}
 
-	return events.LambdaFunctionURLResponse{
+	return events.APIGatewayV2HTTPResponse{
 		StatusCode:      resp.StatusCode,
 		Headers:         headers,
+		Cookies:         setCookies,
 		Body:            body,
 		IsBase64Encoded: isBase64,
 	}, nil
 }
 
 func main() {
+	initHandler()
 	lambda.Start(lambdaHandler)
 }
 
-func toHTTPRequest(ctx context.Context, req events.LambdaFunctionURLRequest) (*http.Request, error) {
+func toHTTPRequest(ctx context.Context, req events.APIGatewayV2HTTPRequest) (*http.Request, error) {
 	url := "https://" + req.RequestContext.DomainName + req.RawPath
 	if req.RawQueryString != "" {
 		url += "?" + req.RawQueryString
@@ -149,6 +159,10 @@ func toHTTPRequest(ctx context.Context, req events.LambdaFunctionURLRequest) (*h
 	}
 	for k, v := range req.Headers {
 		httpReq.Header.Set(k, v)
+	}
+	// API Gateway v2 delivers cookies in a dedicated array, not in the Cookie header.
+	if len(req.Cookies) > 0 {
+		httpReq.Header.Set("Cookie", strings.Join(req.Cookies, "; "))
 	}
 	return httpReq, nil
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -106,6 +105,3 @@ func TestLambdaHandler_NoCookies(t *testing.T) {
 		t.Errorf("expected no cookies, got %v", resp.Cookies)
 	}
 }
-
-// Compile-time check that httptest.NewRecorder is still imported (used by main).
-var _ = httptest.NewRecorder

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func TestToHTTPRequest_CookiesArrayBecomesCookieHeader(t *testing.T) {
+	req := events.APIGatewayV2HTTPRequest{
+		RawPath:        "/auth/callback",
+		RawQueryString: "state=abc&code=xyz",
+		Cookies:        []string{"oauth_nonce=NONCE123", "extra=value"},
+		Headers:        map[string]string{"User-Agent": "test"},
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
+			DomainName: "example.com",
+			HTTP:       events.APIGatewayV2HTTPRequestContextHTTPDescription{Method: "GET"},
+		},
+	}
+
+	httpReq, err := toHTTPRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("toHTTPRequest: %v", err)
+	}
+
+	got, err := httpReq.Cookie("oauth_nonce")
+	if err != nil {
+		t.Fatalf("oauth_nonce cookie not found on request: %v", err)
+	}
+	if got.Value != "NONCE123" {
+		t.Errorf("oauth_nonce value: got %q want %q", got.Value, "NONCE123")
+	}
+	if extra, err := httpReq.Cookie("extra"); err != nil || extra.Value != "value" {
+		t.Errorf("extra cookie missing or wrong: %+v err=%v", extra, err)
+	}
+	if httpReq.URL.RawQuery != "state=abc&code=xyz" {
+		t.Errorf("raw query not preserved: %q", httpReq.URL.RawQuery)
+	}
+}
+
+func TestLambdaHandler_SetCookieGoesIntoCookiesArray(t *testing.T) {
+	// Swap in a tiny handler that always sets two cookies.
+	prev := handler
+	t.Cleanup(func() { handler = prev })
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "a", Value: "1", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "b", Value: "2", Path: "/auth"})
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusFound)
+	})
+
+	resp, err := lambdaHandler(context.Background(), events.APIGatewayV2HTTPRequest{
+		RawPath: "/auth/login",
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
+			DomainName: "example.com",
+			HTTP:       events.APIGatewayV2HTTPRequestContextHTTPDescription{Method: "GET"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("lambdaHandler: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("status: got %d want %d", resp.StatusCode, http.StatusFound)
+	}
+	if len(resp.Cookies) != 2 {
+		t.Fatalf("Cookies: got %d entries (%v), want 2 separate Set-Cookie values", len(resp.Cookies), resp.Cookies)
+	}
+	for _, c := range resp.Cookies {
+		if strings.Contains(c, ", ") {
+			t.Errorf("cookie entry was comma-joined instead of split: %q", c)
+		}
+	}
+	if _, ok := resp.Headers["Set-Cookie"]; ok {
+		t.Error("Set-Cookie must not appear in Headers map; API Gateway v2 requires the Cookies array")
+	}
+}
+
+// Sanity check: a no-cookie handler still works and Cookies is empty/nil.
+func TestLambdaHandler_NoCookies(t *testing.T) {
+	prev := handler
+	t.Cleanup(func() { handler = prev })
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	resp, err := lambdaHandler(context.Background(), events.APIGatewayV2HTTPRequest{
+		RawPath: "/status",
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
+			DomainName: "example.com",
+			HTTP:       events.APIGatewayV2HTTPRequestContextHTTPDescription{Method: "GET"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("lambdaHandler: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d want 200", resp.StatusCode)
+	}
+	if len(resp.Cookies) != 0 {
+		t.Errorf("expected no cookies, got %v", resp.Cookies)
+	}
+}
+
+// Compile-time check that httptest.NewRecorder is still imported (used by main).
+var _ = httptest.NewRecorder


### PR DESCRIPTION
## Summary
- Switch `cmd/server/main.go` to `APIGatewayV2HTTPRequest`/`APIGatewayV2HTTPResponse` so cookies survive the Lambda adapter on both directions. API GW v2 (payload format 2.0) delivers cookies in a top-level `Cookies` array, not in the `Cookie` header, and expects response `Set-Cookie` values back in the same dedicated array. Using the Function URL event types parsed the request without erroring but silently dropped cookies.
- Add `cmd/server/main_test.go` covering the cookie round-trip on both request and response, plus a no-cookies sanity case.
- Move handler wiring out of `init()` into `initHandler()` so the test binary doesn't need AWS config + SSM at startup.
- Anchor binary-ignoring rules in `.gitignore` so `cmd/server/main_test.go` isn't ignored.

## Root cause of the "invalid state" OAuth failure
1. `/auth/login` sets an `oauth_nonce` cookie and 302s to Google with the nonce baked into the `state` param.
2. Google redirects back to `/auth/callback?state=...&code=...`. Browser sends the `oauth_nonce` cookie in the request.
3. API Gateway v2 puts that cookie in `event.Cookies` (NOT in `event.Headers["cookie"]`).
4. The handler decoded into `LambdaFunctionURLRequest`, which has no `Cookies` field — the cookie was silently discarded.
5. `r.Cookie("oauth_nonce")` returns `ErrNoCookie`, the nonce/state check fails, and the response is `400 "invalid state"`.

The regression was introduced in #91 (CloudFront → API Gateway HTTP API migration). It went unnoticed because cookie-bearing paths weren't covered by existing tests.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — full suite green
- [ ] After merge + deploy + propagation delay, run `/mcp` in a fresh Claude Code session and complete the Google OAuth flow end-to-end
- [ ] Confirm a `notoriousmcp` tool call (e.g. list notes) succeeds after auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)