### PR TITLE
docs: note list_users IAM gap as known issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ update_user(user_id=<sub>, status="banned") → ban a user
 
 Admins in `ADMIN_GOOGLE_IDS` are forcibly set to admin on every login, so admin status for bootstrap users cannot be accidentally revoked.
 
+> **Known issue:** `list_users` currently returns `MCP error -32603` against the deployed prod stack because the Lambda IAM role is missing `dynamodb:Scan`. Tracked in [#98](https://github.com/pwntato/notoriousmcp/issues/98). Until fixed, look up pending users with the AWS CLI scan in [Step 3](#step-3--find-your-google-subject-id) and promote them via `update_user` (which uses `UpdateItem` and is unaffected).
+
 ---
 
 ## Skill File


### PR DESCRIPTION
## Summary

- Add a callout in the User Management section pointing to #98 (Lambda IAM role missing `dynamodb:Scan`, causing `list_users` to 500 in prod)
- Point admins at the AWS CLI scan in Step 3 and `update_user` (which uses `UpdateItem` and is unaffected) as the workaround until the IAM fix lands

Found during the post-PR-#97 end-to-end smoke test — every other tool category (notes, todos, files) round-tripped cleanly.

## Test plan

- [ ] README renders correctly on GitHub (admonition block, working anchor link to Step 3, working issue link to #98)