### PR TITLE
fix: grant dynamodb:Scan to Lambda role so list_users works in prod

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -30,6 +30,7 @@ data "aws_iam_policy_document" "lambda_policy" {
       "dynamodb:UpdateItem",
       "dynamodb:DeleteItem",
       "dynamodb:Query",
+      "dynamodb:Scan",
     ]
     resources = [
       aws_dynamodb_table.main.arn,


### PR DESCRIPTION
## Summary

- Add `dynamodb:Scan` to `aws_iam_role_policy.lambda` in `terraform/lambda.tf`
- `list_users` uses `dynamodb.Scan` intentionally (admin-only, low-cardinality path — see `internal/db/users.go:205-209`); the IAM policy covered Get/Put/Update/Delete/Query but not Scan
- This caused `AccessDeniedException` in prod, surfacing as MCP error `-32603` on every `list_users` call

## IAM chicken-and-egg

The Lambda *runtime* role (`aws_iam_role_policy.lambda`) can't be updated by CI — the deploy role can't grant itself new runtime permissions. Applied locally first via:

```
terraform apply -target=aws_iam_role_policy.lambda
```

CI will confirm the rest of the config is in sync on merge.

## Test plan

- [ ] CI plan shows 0 changes to `aws_iam_role_policy.lambda` (already applied)
- [ ] `list_users` returns my user (Google sub `108382265619994353524`) as admin in a fresh Claude Code session after merge

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)