### PR TITLE
feat: configurable OAuth provider — Google (default) or Okta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ OAUTH_CLIENT_ID=
 OAUTH_CLIENT_SECRET=
 
 # Required when OAUTH_PROVIDER=okta (e.g. dev-123.okta.com)
+# Uses the Okta default authorization server (/oauth2/default). If your org uses
+# a custom auth server (e.g. /oauth2/auXXXXXX), this will not work as-is.
 # OKTA_DOMAIN=
 
 # Local dev only — these are set automatically by docker-compose

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
-# Google OAuth (from Google Cloud Console)
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
+# OAuth provider — "google" (default) or "okta"
+OAUTH_PROVIDER=google
+OAUTH_CLIENT_ID=
+OAUTH_CLIENT_SECRET=
+
+# Required when OAUTH_PROVIDER=okta (e.g. dev-123.okta.com)
+# OKTA_DOMAIN=
 
 # Local dev only — these are set automatically by docker-compose
 DYNAMODB_ENDPOINT=http://localhost:8000
@@ -14,6 +18,6 @@ ENVIRONMENT=local
 AWS_ACCESS_KEY_ID=localuser
 AWS_SECRET_ACCESS_KEY=localpassword
 
-# Admin bootstrap: comma-separated Google subject IDs
+# Admin bootstrap: comma-separated provider subject IDs (sub claim)
 # Get your sub by logging in once and checking the DynamoDB USER#<sub>#PROFILE item
-ADMIN_GOOGLE_IDS=
+ADMIN_IDS=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,9 +48,9 @@ jobs:
         env:
           TF_VAR_aws_region: us-west-2
           TF_VAR_state_bucket: ${{ vars.TF_STATE_BUCKET }}
-          TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
-          TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          TF_VAR_admin_google_ids: ${{ secrets.ADMIN_GOOGLE_IDS }}
+          TF_VAR_oauth_client_id: ${{ secrets.OAUTH_CLIENT_ID }}
+          TF_VAR_oauth_client_secret: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          TF_VAR_admin_ids: ${{ secrets.ADMIN_IDS }}
           TF_VAR_token_secret: ${{ secrets.TOKEN_SECRET }}
           TF_VAR_redirect_url: ${{ vars.REDIRECT_URL }}
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Lambda Function  (arm64, 256MB, 30s timeout)
 
 New accounts start as **pending** and can only call `check_status`. An admin must promote them to **user** or **admin**.
 
-**Admin bootstrap:** The `ADMIN_GOOGLE_IDS` SSM parameter holds a comma-separated list of Google subject IDs that are forcibly set to `admin` status on every login. This self-heals if admin status is accidentally removed.
+**Admin bootstrap:** The `ADMIN_IDS` SSM parameter holds a comma-separated list of provider subject IDs (`sub` claim) that are forcibly set to `admin` status on every login. This self-heals if admin status is accidentally removed.
 
 ---
 
@@ -84,7 +84,7 @@ All other services are effectively free at personal-use scale. The AWS Free Tier
 - Terraform ≥ 1.0
 - Go ≥ 1.26 (see `go.mod`; this is a release candidate toolchain — download from [go.dev/dl](https://go.dev/dl); for local builds only, CI builds in GitHub Actions)
 - GitHub repository (for OIDC-based CI/CD)
-- A Google account (for OAuth)
+- A Google account or Okta org (for OAuth)
 
 ---
 
@@ -147,7 +147,7 @@ aws dynamodb scan --table-name notoriousmcp \
   | jq -r '.Items[] | select(.SK.S == "PROFILE") | {id: .PK.S, email: .Email.S}'
 ```
 
-The `sub` value looks like `123456789012345678901`. You'll set this as `ADMIN_GOOGLE_IDS` in Step 4.
+The `sub` value looks like `123456789012345678901`. You'll set this as `ADMIN_IDS` in Step 4.
 
 ---
 
@@ -158,9 +158,9 @@ In your GitHub repository, go to **Settings → Secrets and variables → Action
 | Name | Type | Value | Where it comes from |
 |------|------|-------|---------------------|
 | `AWS_DEPLOY_ROLE_ARN` | Secret | IAM role ARN | `terraform output deploy_role_arn` after first deploy\* |
-| `GOOGLE_CLIENT_ID` | Secret | OAuth client ID | Step 1 |
-| `GOOGLE_CLIENT_SECRET` | Secret | OAuth client secret | Step 1 |
-| `ADMIN_GOOGLE_IDS` | Secret | Comma-separated Google subject IDs | Step 3 |
+| `OAUTH_CLIENT_ID` | Secret | OAuth client ID | Step 1 |
+| `OAUTH_CLIENT_SECRET` | Secret | OAuth client secret | Step 1 |
+| `ADMIN_IDS` | Secret | Comma-separated provider subject IDs | Step 3 |
 | `TOKEN_SECRET` | Secret | Random string ≥ 32 bytes | `openssl rand -base64 32` |
 | `TF_STATE_BUCKET` | Variable | S3 bucket name | Step 2 output (`state_bucket`) |
 | `REDIRECT_URL` | Variable | Full OAuth callback URL | `https://<api-gateway-domain>/auth/callback` (set after Step 5; Terraform uses the lowercase `redirect_url` var name) |
@@ -213,9 +213,9 @@ terraform import aws_iam_openid_connect_provider.github \
 
 ```bash
 terraform apply \
-  -var="google_client_id=<CLIENT_ID>" \
-  -var="google_client_secret=<CLIENT_SECRET>" \
-  -var="admin_google_ids=<YOUR_GOOGLE_SUB>" \
+  -var="oauth_client_id=<CLIENT_ID>" \
+  -var="oauth_client_secret=<CLIENT_SECRET>" \
+  -var="admin_ids=<YOUR_SUB>" \
   -var="redirect_url=https://<api-gateway-domain>/auth/callback"
   # TF_VAR_token_secret is picked up from the env var set above
 ```
@@ -234,9 +234,9 @@ Then:
 2. Re-apply with the real `redirect_url` (reuse the same `TF_VAR_token_secret`):
    ```bash
    terraform apply \
-     -var="google_client_id=<CLIENT_ID>" \
-     -var="google_client_secret=<CLIENT_SECRET>" \
-     -var="admin_google_ids=<YOUR_GOOGLE_SUB>" \
+     -var="oauth_client_id=<CLIENT_ID>" \
+     -var="oauth_client_secret=<CLIENT_SECRET>" \
+     -var="admin_ids=<YOUR_SUB>" \
      -var="redirect_url=https://<api-gateway-domain>/auth/callback"
      # TF_VAR_token_secret is picked up from the env var set above
    ```
@@ -267,9 +267,9 @@ To use a custom domain instead of the API Gateway URL, add domain variables to y
 
 ```bash
 terraform apply \
-  -var="google_client_id=<CLIENT_ID>" \
-  -var="google_client_secret=<CLIENT_SECRET>" \
-  -var="admin_google_ids=<YOUR_GOOGLE_SUB>" \
+  -var="oauth_client_id=<CLIENT_ID>" \
+  -var="oauth_client_secret=<CLIENT_SECRET>" \
+  -var="admin_ids=<YOUR_SUB>" \
   -var="redirect_url=https://<your-domain>/auth/callback" \
   -var="domain_name=notoriousmcp.example.com" \
   -var="domain_contact_first_name=Jane" \
@@ -292,7 +292,7 @@ This registers the domain via Route53 and wires ACM + API Gateway automatically.
 
 After deploy, visit `https://<your-api-gateway-domain>/auth/login` and sign in with Google. Your account is created as **pending**.
 
-If your Google subject ID was in `ADMIN_GOOGLE_IDS`, you're automatically set to **admin** on login — no approval needed. Skip to Step 7.
+If your subject ID was in `ADMIN_IDS`, you're automatically set to **admin** on login — no approval needed. Skip to Step 7.
 
 Otherwise, an existing admin must promote you. If you're setting up for the first time and have no admin yet, use the AWS CLI to update your user record directly:
 
@@ -374,14 +374,18 @@ docker compose up server
 Key `.env` values for local dev:
 
 ```bash
-GOOGLE_CLIENT_ID=<from Google Cloud Console>
-GOOGLE_CLIENT_SECRET=<from Google Cloud Console>
+OAUTH_CLIENT_ID=<from Google Cloud Console or Okta>
+OAUTH_CLIENT_SECRET=<from Google Cloud Console or Okta>
 REDIRECT_URL=http://localhost:3000/auth/callback
 TOKEN_SECRET=<any string ≥ 32 bytes>
-ADMIN_GOOGLE_IDS=<your Google subject ID>
+ADMIN_IDS=<your provider subject ID>
+
+# To use Okta instead of Google:
+# OAUTH_PROVIDER=okta
+# OKTA_DOMAIN=dev-123.okta.com
 ```
 
-Add `http://localhost:3000/auth/callback` as an authorized redirect URI in your Google OAuth app (Step 1).
+Add `http://localhost:3000/auth/callback` as an authorized redirect URI in your OAuth app.
 
 **Run tests:**
 
@@ -424,9 +428,9 @@ update_user(user_id=<sub>, status="admin")  → promote to admin
 update_user(user_id=<sub>, status="banned") → ban a user
 ```
 
-`user_id` is the Google subject ID (`sub`) — visible in `list_users` output.
+`user_id` is the provider subject ID (`sub` claim) — visible in `list_users` output.
 
-Admins in `ADMIN_GOOGLE_IDS` are forcibly set to admin on every login, so admin status for bootstrap users cannot be accidentally revoked.
+Admins in `ADMIN_IDS` are forcibly set to admin on every login, so admin status for bootstrap users cannot be accidentally revoked.
 
 ---
 

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -31,15 +31,17 @@ func main() {
 		log.Fatalf("store: %v", err)
 	}
 
-	adminIDs := strings.Split(os.Getenv("ADMIN_GOOGLE_IDS"), ",")
+	adminIDs := strings.Split(os.Getenv("ADMIN_IDS"), ",")
 	tokenSecret := []byte(envOrDefault("TOKEN_SECRET", "local-dev-secret-key-at-least-32!!"))
 	authCfg := auth.Config{
-		ClientID:       envOrDefault("GOOGLE_CLIENT_ID", "local-client-id"),
-		ClientSecret:   envOrDefault("GOOGLE_CLIENT_SECRET", "local-client-secret"),
-		RedirectURL:    envOrDefault("REDIRECT_URL", "http://localhost:3000/auth/callback"),
-		AdminGoogleIDs: filterEmpty(adminIDs),
-		TokenSecret:    tokenSecret,
-		TrustProxy:     false,
+		Provider:     auth.OAuthProvider(os.Getenv("OAUTH_PROVIDER")),
+		OktaDomain:   os.Getenv("OKTA_DOMAIN"),
+		ClientID:     envOrDefault("OAUTH_CLIENT_ID", "local-client-id"),
+		ClientSecret: envOrDefault("OAUTH_CLIENT_SECRET", "local-client-secret"),
+		RedirectURL:  envOrDefault("REDIRECT_URL", "http://localhost:3000/auth/callback"),
+		AdminIDs:     filterEmpty(adminIDs),
+		TokenSecret:  tokenSecret,
+		TrustProxy:   false,
 	}
 
 	authHandler := auth.New(authCfg, dbClient)
@@ -87,7 +89,7 @@ func envOrDefault(key, def string) string {
 }
 
 // filterEmpty removes empty strings. Needed because strings.Split("", ",") returns
-// [""] rather than [], so an unset ADMIN_GOOGLE_IDS env var must be cleaned before
+// [""] rather than [], so an unset ADMIN_IDS env var must be cleaned before
 // passing to auth.Config.
 func filterEmpty(ss []string) []string {
 	var out []string

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -62,16 +62,18 @@ func initHandler() {
 		log.Fatalf("store: %v", err)
 	}
 
-	adminIDsRaw := ssmGet(mustEnv("SSM_ADMIN_GOOGLE_IDS"))
+	adminIDsRaw := ssmGet(mustEnv("SSM_ADMIN_IDS"))
 	tokenSecretRaw := ssmGet(mustEnv("SSM_TOKEN_SECRET"))
 	authCfg := auth.Config{
-		ClientID:       ssmGet(mustEnv("SSM_GOOGLE_CLIENT_ID")),
-		ClientSecret:   ssmGet(mustEnv("SSM_GOOGLE_CLIENT_SECRET")),
-		RedirectURL:    mustEnv("REDIRECT_URL"),
-		AdminGoogleIDs: filterEmpty(strings.Split(adminIDsRaw, ",")),
-		TokenSecret:    []byte(tokenSecretRaw),
-		TrustProxy:     true,
-		PublicBaseURL:  os.Getenv("PUBLIC_BASE_URL"),
+		Provider:     auth.OAuthProvider(os.Getenv("OAUTH_PROVIDER")),
+		OktaDomain:   os.Getenv("OKTA_DOMAIN"),
+		ClientID:     ssmGet(mustEnv("SSM_OAUTH_CLIENT_ID")),
+		ClientSecret: ssmGet(mustEnv("SSM_OAUTH_CLIENT_SECRET")),
+		RedirectURL:  mustEnv("REDIRECT_URL"),
+		AdminIDs:     filterEmpty(strings.Split(adminIDsRaw, ",")),
+		TokenSecret:  []byte(tokenSecretRaw),
+		TrustProxy:   true,
+		PublicBaseURL: os.Getenv("PUBLIC_BASE_URL"),
 	}
 
 	authHandler := auth.New(authCfg, dbClient)

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -44,6 +44,10 @@ type Config struct {
 // providerEndpoint returns the oauth2.Endpoint for the configured provider.
 // For Okta it derives endpoints from the domain; for Google it uses the
 // well-known constant from golang.org/x/oauth2/google.
+//
+// OverrideTokenURL is for tests only — it returns an endpoint with only
+// TokenURL set (AuthURL is empty), which is fine for token-exchange tests
+// but would break a full authorization redirect.
 func (c Config) providerEndpoint() oauth2.Endpoint {
 	if c.OverrideTokenURL != "" {
 		return oauth2.Endpoint{TokenURL: c.OverrideTokenURL}

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -4,16 +4,29 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// OAuthProvider selects which upstream OAuth 2.0 / OIDC provider to use.
+type OAuthProvider string
+
+const (
+	ProviderGoogle OAuthProvider = "google"
+	ProviderOkta   OAuthProvider = "okta"
 )
 
 // Config holds OAuth credentials and server settings needed by the auth layer.
 // Call Validate() before passing to New().
 type Config struct {
-	ClientID       string
-	ClientSecret   string
-	RedirectURL    string   // e.g. https://notoriousmcp.com/auth/callback
-	AdminGoogleIDs []string // subject IDs that are always promoted to admin on login
-	TokenSecret    []byte   // HMAC-SHA256 secret for signing access tokens; min 32 bytes
+	Provider     OAuthProvider // "google" (default) or "okta"
+	OktaDomain   string        // required when Provider == ProviderOkta, e.g. "dev-123.okta.com"
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string   // e.g. https://notoriousmcp.com/auth/callback
+	AdminIDs     []string // subject IDs (provider "sub" claim) always promoted to admin on login
+	TokenSecret  []byte   // HMAC-SHA256 secret for signing access tokens; min 32 bytes
 	// TrustProxy enables X-Forwarded-Proto scheme detection. Set true only when
 	// running behind a trusted reverse proxy (CloudFront/ALB). Never set on
 	// direct-to-internet deployments — it allows scheme downgrade spoofing.
@@ -23,9 +36,46 @@ type Config struct {
 	// deriving from r.Host (which reflects the Lambda URL behind CloudFront, not the
 	// public CloudFront domain).
 	PublicBaseURL string
-	// GoogleTokenURL overrides Google's token endpoint. Empty means use the
-	// default (google.Endpoint). Set in tests only to point at a fake server.
-	GoogleTokenURL string
+	// OverrideTokenURL overrides the provider token endpoint. Empty means use the
+	// provider default. Set in tests only to point at a fake server.
+	OverrideTokenURL string
+}
+
+// providerEndpoint returns the oauth2.Endpoint for the configured provider.
+// For Okta it derives endpoints from the domain; for Google it uses the
+// well-known constant from golang.org/x/oauth2/google.
+func (c Config) providerEndpoint() oauth2.Endpoint {
+	if c.OverrideTokenURL != "" {
+		return oauth2.Endpoint{TokenURL: c.OverrideTokenURL}
+	}
+	switch c.provider() {
+	case ProviderOkta:
+		base := "https://" + c.OktaDomain + "/oauth2/default"
+		return oauth2.Endpoint{
+			AuthURL:  base + "/v1/authorize",
+			TokenURL: base + "/v1/token",
+		}
+	default:
+		return google.Endpoint
+	}
+}
+
+// userInfoURL returns the OIDC userinfo endpoint for the configured provider.
+func (c Config) userInfoURL() string {
+	switch c.provider() {
+	case ProviderOkta:
+		return "https://" + c.OktaDomain + "/oauth2/default/v1/userinfo"
+	default:
+		return "https://openidconnect.googleapis.com/v1/userinfo"
+	}
+}
+
+// provider returns the effective provider, defaulting to Google when unset.
+func (c Config) provider() OAuthProvider {
+	if c.Provider == "" {
+		return ProviderGoogle
+	}
+	return c.Provider
 }
 
 // publicBase returns the canonical public base URL with no trailing slash.
@@ -50,6 +100,9 @@ func (c Config) Validate() error {
 	}
 	if len(c.TokenSecret) < 32 {
 		return fmt.Errorf("auth.Config.TokenSecret must be at least 32 bytes (got %d)", len(c.TokenSecret))
+	}
+	if c.provider() == ProviderOkta && c.OktaDomain == "" {
+		return fmt.Errorf("auth.Config.OktaDomain is required when Provider is okta")
 	}
 	return nil
 }

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -24,3 +24,13 @@ func IssueExpiredToken(secret []byte, userID string) (string, error) {
 
 // ValidSignatureUserID exposes validSignatureUserID for testing.
 var ValidSignatureUserID = validSignatureUserID
+
+// ProviderEndpoint exposes Config.providerEndpoint for testing.
+// Returns (authURL, tokenURL).
+func (c Config) ProviderEndpoint() (string, string) {
+	ep := c.providerEndpoint()
+	return ep.AuthURL, ep.TokenURL
+}
+
+// UserInfoURL exposes Config.userInfoURL for testing.
+func (c Config) UserInfoURL() string { return c.userInfoURL() }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 
 	"github.com/pwntato/notoriousmcp/internal/db"
 	"github.com/pwntato/notoriousmcp/internal/models"
@@ -39,16 +38,16 @@ func New(cfg Config, dbClient *db.Client) *Handler {
 	}
 	// Log admin sub IDs at startup so promotions are observable in logs.
 	// Logged as count + first-8-chars of each ID for auditability without
-	// exposing full Google subject IDs.
-	adminHints := make([]string, len(cfg.AdminGoogleIDs))
-	for i, id := range cfg.AdminGoogleIDs {
+	// exposing full subject IDs.
+	adminHints := make([]string, len(cfg.AdminIDs))
+	for i, id := range cfg.AdminIDs {
 		if len(id) > 8 {
 			adminHints[i] = id[:8] + "..."
 		} else {
 			adminHints[i] = id
 		}
 	}
-	log.Printf("auth: %d admin ID(s) configured: %v", len(cfg.AdminGoogleIDs), adminHints)
+	log.Printf("auth: %d admin ID(s) configured: %v", len(cfg.AdminIDs), adminHints)
 	return &Handler{
 		cfg: cfg,
 		db:  dbClient,
@@ -57,7 +56,7 @@ func New(cfg Config, dbClient *db.Client) *Handler {
 			ClientSecret: cfg.ClientSecret,
 			RedirectURL:  cfg.RedirectURL,
 			Scopes:       []string{"openid", "email", "profile"},
-			Endpoint:     google.Endpoint,
+			Endpoint:     cfg.providerEndpoint(),
 		},
 	}
 }
@@ -270,8 +269,8 @@ func (h *Handler) callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch Google user info.
-	info, err := fetchGoogleUserInfo(ctx, h.oauthCfg.Client(ctx, oauthToken))
+	// Fetch user info from the provider's userinfo endpoint.
+	info, err := fetchUserInfo(ctx, h.cfg.userInfoURL(), h.oauthCfg.Client(ctx, oauthToken))
 	if err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
@@ -389,10 +388,7 @@ func ValidateRedirectURI(configuredRedirectURL, clientRedirectURI string) error 
 	return nil
 }
 
-const (
-	googleUserInfoURL = "https://openidconnect.googleapis.com/v1/userinfo"
-	authCodeTTL       = 60 * time.Second
-)
+const authCodeTTL = 60 * time.Second
 
 // writeJSONError writes an RFC 6749-style JSON error response.
 func writeJSONError(w http.ResponseWriter, status int, errCode string) {
@@ -560,14 +556,18 @@ func (h *Handler) token(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-type googleUserInfo struct {
+type userInfo struct {
 	Sub   string `json:"sub"`
 	Email string `json:"email"`
 	Name  string `json:"name"`
 }
 
-func fetchGoogleUserInfo(ctx context.Context, client *http.Client) (*googleUserInfo, error) {
-	resp, err := client.Get(googleUserInfoURL)
+func fetchUserInfo(ctx context.Context, userinfoURL string, client *http.Client) (*userInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, userinfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("userinfo request: %w", err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("userinfo request: %w", err)
 	}
@@ -575,11 +575,11 @@ func fetchGoogleUserInfo(ctx context.Context, client *http.Client) (*googleUserI
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("userinfo status %d", resp.StatusCode)
 	}
-	// Limit response size — Google's userinfo payload is tiny but defense-in-depth.
+	// Limit response size — provider userinfo payloads are tiny but defense-in-depth.
 	// io.LimitedReader is used rather than http.MaxBytesReader to avoid passing
 	// a nil ResponseWriter (undocumented behaviour).
 	limited := &io.LimitedReader{R: resp.Body, N: 64 * 1024}
-	var info googleUserInfo
+	var info userInfo
 	if err := json.NewDecoder(limited).Decode(&info); err != nil {
 		return nil, fmt.Errorf("userinfo decode: %w", err)
 	}
@@ -593,10 +593,10 @@ func fetchGoogleUserInfo(ctx context.Context, client *http.Client) (*googleUserI
 // Note: GetUser → SaveUser is a non-atomic read-modify-write. Two concurrent
 // first-logins race safely: (a) SaveUser uses if_not_exists(CreatedAt) so
 // CreatedAt is never overwritten, (b) both concurrent reads return ErrNotFound,
-// both set status=pending (or status=admin for AdminGoogleIDs users), so both
+// both set status=pending (or status=admin for AdminIDs users), so both
 // writes produce the same result. Subsequent logins skip the write entirely when
 // status/email/name haven't changed, so they are also idempotent.
-func (h *Handler) upsertUser(ctx context.Context, info *googleUserInfo, refreshToken string) error {
+func (h *Handler) upsertUser(ctx context.Context, info *userInfo, refreshToken string) error {
 	existing, err := h.db.GetUser(ctx, info.Sub)
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
 		return fmt.Errorf("get user: %w", err)
@@ -607,8 +607,8 @@ func (h *Handler) upsertUser(ctx context.Context, info *googleUserInfo, refreshT
 		status = existing.Status
 	}
 
-	// Admin bootstrap: ADMIN_GOOGLE_IDS always wins, self-heals on every login.
-	if slices.Contains(h.cfg.AdminGoogleIDs, info.Sub) {
+	// Admin bootstrap: ADMIN_IDS always wins, self-heals on every login.
+	if slices.Contains(h.cfg.AdminIDs, info.Sub) {
 		status = models.StatusAdmin
 	}
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -930,3 +930,23 @@ func TestOktaValidateMissingDomain(t *testing.T) {
 		t.Error("expected error for okta provider with no OktaDomain")
 	}
 }
+
+func TestDefaultProviderIsGoogle(t *testing.T) {
+	cfg := auth.Config{
+		// Provider intentionally unset — should default to Google
+		ClientID:     "id",
+		ClientSecret: "secret",
+		RedirectURL:  "https://example.com/auth/callback",
+		TokenSecret:  []byte("exactly-32-bytes-long-secret-key!"),
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("empty Provider should be valid (defaults to google): %v", err)
+	}
+	authURL, _ := cfg.ProviderEndpoint()
+	if authURL != "https://accounts.google.com/o/oauth2/auth" {
+		t.Errorf("default provider AuthURL: got %q, want Google's", authURL)
+	}
+	if got := cfg.UserInfoURL(); got != "https://openidconnect.googleapis.com/v1/userinfo" {
+		t.Errorf("default provider UserInfoURL: got %q", got)
+	}
+}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -891,3 +891,42 @@ func TestConfigValidate(t *testing.T) {
 		t.Error("expected error for empty ClientSecret")
 	}
 }
+
+func TestOktaProviderEndpoints(t *testing.T) {
+	cfg := auth.Config{
+		Provider:     auth.ProviderOkta,
+		OktaDomain:   "test.okta.com",
+		ClientID:     "id",
+		ClientSecret: "secret",
+		RedirectURL:  "https://example.com/auth/callback",
+		TokenSecret:  []byte("exactly-32-bytes-long-secret-key!"),
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid okta config failed: %v", err)
+	}
+
+	authURL, tokenURL := cfg.ProviderEndpoint()
+	if authURL != "https://test.okta.com/oauth2/default/v1/authorize" {
+		t.Errorf("AuthURL: got %q", authURL)
+	}
+	if tokenURL != "https://test.okta.com/oauth2/default/v1/token" {
+		t.Errorf("TokenURL: got %q", tokenURL)
+	}
+
+	if got := cfg.UserInfoURL(); got != "https://test.okta.com/oauth2/default/v1/userinfo" {
+		t.Errorf("UserInfoURL: got %q", got)
+	}
+}
+
+func TestOktaValidateMissingDomain(t *testing.T) {
+	cfg := auth.Config{
+		Provider:     auth.ProviderOkta,
+		ClientID:     "id",
+		ClientSecret: "secret",
+		RedirectURL:  "https://example.com/auth/callback",
+		TokenSecret:  []byte("exactly-32-bytes-long-secret-key!"),
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for okta provider with no OktaDomain")
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -159,8 +159,8 @@ func tryRefresh(ctx context.Context, cfg Config, dbClient *db.Client, rawToken s
 
 	rotatedToken, err := exchangeRefreshToken(ctx, cfg, storedToken)
 	if err != nil {
-		// Token was revoked or otherwise rejected by Google — remove it so future
-		// refresh attempts fail fast without hitting Google unnecessarily.
+		// Token was revoked or otherwise rejected by the provider — remove it so
+		// future refresh attempts fail fast without hitting the provider unnecessarily.
 		if delErr := dbClient.DeleteRefreshToken(ctx, userID); delErr != nil {
 			log.Printf("auth: delete revoked refresh token for %s: %v", userID, delErr)
 		}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 
 	"github.com/pwntato/notoriousmcp/internal/db"
 	"github.com/pwntato/notoriousmcp/internal/models"
@@ -39,10 +38,10 @@ func WithUserContext(ctx context.Context, user *models.User) context.Context {
 // DynamoDB (never trusting embedded token claims for authorization), and injects
 // the user into the request context.
 //
-// If the token is expired and the user has a stored Google refresh token,
-// the token is exchanged live with Google's token endpoint to confirm it is
-// still valid. On success a fresh notoriousmcp access token is issued and
-// delivered via X-New-Token. If Google rejects the token (revoked/expired),
+// If the token is expired and the user has a stored provider refresh token,
+// the token is exchanged live with the provider's token endpoint to confirm it
+// is still valid. On success a fresh notoriousmcp access token is issued and
+// delivered via X-New-Token. If the provider rejects the token (revoked/expired),
 // the stored token is deleted from DynamoDB and the request gets 401.
 // X-New-Token is only written when next responds with a 2xx status code —
 // the response is buffered to enforce this. A 401, 403, or 5xx from next
@@ -158,7 +157,7 @@ func tryRefresh(ctx context.Context, cfg Config, dbClient *db.Client, rawToken s
 		return "", "", err
 	}
 
-	rotatedToken, err := exchangeGoogleRefreshToken(ctx, cfg, storedToken)
+	rotatedToken, err := exchangeRefreshToken(ctx, cfg, storedToken)
 	if err != nil {
 		// Token was revoked or otherwise rejected by Google — remove it so future
 		// refresh attempts fail fast without hitting Google unnecessarily.
@@ -168,8 +167,8 @@ func tryRefresh(ctx context.Context, cfg Config, dbClient *db.Client, rawToken s
 		return "", "", ErrInvalidToken
 	}
 
-	// Google rotates refresh tokens for inactive users. Persist the new token so
-	// the stored value doesn't silently go stale.
+	// Some providers rotate refresh tokens for inactive users. Persist the new
+	// token so the stored value doesn't silently go stale.
 	if rotatedToken != "" && rotatedToken != storedToken {
 		if saveErr := dbClient.SaveRefreshToken(ctx, userID, rotatedToken); saveErr != nil {
 			log.Printf("auth: save rotated refresh token for %s: %v", userID, saveErr)
@@ -183,19 +182,15 @@ func tryRefresh(ctx context.Context, cfg Config, dbClient *db.Client, rawToken s
 	return newToken, userID, nil
 }
 
-// exchangeGoogleRefreshToken performs a live token exchange with Google to
-// confirm the stored refresh token is still valid. It returns the new refresh
-// token (non-empty only when Google rotates it) and a non-nil error if Google
-// rejects the token.
-func exchangeGoogleRefreshToken(ctx context.Context, cfg Config, refreshToken string) (newRefreshToken string, err error) {
-	endpoint := google.Endpoint
-	if cfg.GoogleTokenURL != "" {
-		endpoint = oauth2.Endpoint{TokenURL: cfg.GoogleTokenURL}
-	}
+// exchangeRefreshToken performs a live token exchange with the configured
+// provider to confirm the stored refresh token is still valid. It returns the
+// new refresh token (non-empty only when the provider rotates it) and a non-nil
+// error if the provider rejects the token.
+func exchangeRefreshToken(ctx context.Context, cfg Config, refreshToken string) (newRefreshToken string, err error) {
 	oauthCfg := &oauth2.Config{
 		ClientID:     cfg.ClientID,
 		ClientSecret: cfg.ClientSecret,
-		Endpoint:     endpoint,
+		Endpoint:     cfg.providerEndpoint(),
 	}
 	src := oauthCfg.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken})
 	tok, err := src.Token()

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -181,11 +181,11 @@ func TestUserFromContextNil(t *testing.T) {
 	}
 }
 
-// fakeGoogleTokenServer starts an httptest server that simulates Google's token
-// endpoint. When accept is true it returns a well-formed token response;
+// fakeTokenServer starts an httptest server that simulates an OAuth provider's
+// token endpoint. When accept is true it returns a well-formed token response;
 // otherwise it returns 400 with an "invalid_grant" error body (revoked token).
 // The caller must call server.Close() when done.
-func fakeGoogleTokenServer(t *testing.T, accept bool) *httptest.Server {
+func fakeTokenServer(t *testing.T, accept bool) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !accept {
@@ -393,10 +393,10 @@ func TestMiddlewareExpiredTokenRefreshSuccess(t *testing.T) {
 		t.Fatalf("issue expired: %v", err)
 	}
 
-	googleSrv := fakeGoogleTokenServer(t, true)
-	defer googleSrv.Close()
+	tokenSrv := fakeTokenServer(t, true)
+	defer tokenSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(tokenSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -441,14 +441,14 @@ func TestMiddlewareXNewTokenAbsentOnNextError(t *testing.T) {
 		t.Fatalf("issue expired: %v", err)
 	}
 
-	googleSrv := fakeGoogleTokenServer(t, true)
-	defer googleSrv.Close()
+	tokenSrv := fakeTokenServer(t, true)
+	defer tokenSrv.Close()
 
 	errorHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)
 	})
 
-	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, errorHandler)
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(tokenSrv.URL), dbClient, errorHandler)
 	req := httptest.NewRequest("GET", "/missing", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -499,10 +499,10 @@ func TestMiddlewareExpiredTokenRefreshBannedUser(t *testing.T) {
 		t.Fatalf("issue expired: %v", err)
 	}
 
-	googleSrv := fakeGoogleTokenServer(t, true)
-	defer googleSrv.Close()
+	tokenSrv := fakeTokenServer(t, true)
+	defer tokenSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(tokenSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -533,7 +533,7 @@ func TestMiddlewareRefreshTokenRotation(t *testing.T) {
 
 	// Fake Google server returns a *different* refresh token, simulating rotation.
 	rotatedToken := "rotated-google-refresh-token"
-	googleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token":  "google-access-token",
@@ -542,9 +542,9 @@ func TestMiddlewareRefreshTokenRotation(t *testing.T) {
 			"refresh_token": rotatedToken,
 		})
 	}))
-	defer googleSrv.Close()
+	defer tokenSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(tokenSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -581,7 +581,7 @@ func TestMiddlewareRefreshTokenNoRotation(t *testing.T) {
 	}
 
 	// Fake Google server returns no refresh_token field (omitted = empty string in oauth2 lib).
-	googleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token": "google-access-token",
@@ -590,9 +590,9 @@ func TestMiddlewareRefreshTokenNoRotation(t *testing.T) {
 			// refresh_token intentionally omitted
 		})
 	}))
-	defer googleSrv.Close()
+	defer tokenSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(tokenSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -627,10 +627,10 @@ func TestMiddlewareExpiredTokenRevokedRefreshToken(t *testing.T) {
 		t.Fatalf("issue expired: %v", err)
 	}
 
-	googleSrv := fakeGoogleTokenServer(t, false) // Google returns 400 invalid_grant
-	defer googleSrv.Close()
+	tokenSrv := fakeTokenServer(t, false) // Google returns 400 invalid_grant
+	defer tokenSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(tokenSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -627,7 +627,7 @@ func TestMiddlewareExpiredTokenRevokedRefreshToken(t *testing.T) {
 		t.Fatalf("issue expired: %v", err)
 	}
 
-	tokenSrv := fakeTokenServer(t, false) // Google returns 400 invalid_grant
+	tokenSrv := fakeTokenServer(t, false) // provider returns 400 invalid_grant (revoked)
 	defer tokenSrv.Close()
 
 	h := auth.Middleware(testMiddlewareCfgWithTokenURL(tokenSrv.URL), dbClient, http.HandlerFunc(okHandler))

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -27,9 +27,9 @@ func testMiddlewareCfg() auth.Config {
 	}
 }
 
-func testMiddlewareCfgWithGoogleURL(googleTokenURL string) auth.Config {
+func testMiddlewareCfgWithTokenURL(tokenURL string) auth.Config {
 	cfg := testMiddlewareCfg()
-	cfg.GoogleTokenURL = googleTokenURL
+	cfg.OverrideTokenURL = tokenURL
 	return cfg
 }
 
@@ -396,7 +396,7 @@ func TestMiddlewareExpiredTokenRefreshSuccess(t *testing.T) {
 	googleSrv := fakeGoogleTokenServer(t, true)
 	defer googleSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithGoogleURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -448,7 +448,7 @@ func TestMiddlewareXNewTokenAbsentOnNextError(t *testing.T) {
 		http.Error(w, "not found", http.StatusNotFound)
 	})
 
-	h := auth.Middleware(testMiddlewareCfgWithGoogleURL(googleSrv.URL), dbClient, errorHandler)
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, errorHandler)
 	req := httptest.NewRequest("GET", "/missing", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -502,7 +502,7 @@ func TestMiddlewareExpiredTokenRefreshBannedUser(t *testing.T) {
 	googleSrv := fakeGoogleTokenServer(t, true)
 	defer googleSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithGoogleURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -544,7 +544,7 @@ func TestMiddlewareRefreshTokenRotation(t *testing.T) {
 	}))
 	defer googleSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithGoogleURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -592,7 +592,7 @@ func TestMiddlewareRefreshTokenNoRotation(t *testing.T) {
 	}))
 	defer googleSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithGoogleURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()
@@ -630,7 +630,7 @@ func TestMiddlewareExpiredTokenRevokedRefreshToken(t *testing.T) {
 	googleSrv := fakeGoogleTokenServer(t, false) // Google returns 400 invalid_grant
 	defer googleSrv.Close()
 
-	h := auth.Middleware(testMiddlewareCfgWithGoogleURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
+	h := auth.Middleware(testMiddlewareCfgWithTokenURL(googleSrv.URL), dbClient, http.HandlerFunc(okHandler))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer "+expired)
 	w := httptest.NewRecorder()

--- a/terraform/iam_deploy.tf
+++ b/terraform/iam_deploy.tf
@@ -96,9 +96,9 @@ data "aws_iam_policy_document" "deploy_policy" {
   statement {
     actions = ["ssm:GetParameter", "ssm:GetParameters", "ssm:ListTagsForResource"]
     resources = [
-      aws_ssm_parameter.google_client_id.arn,
-      aws_ssm_parameter.google_client_secret.arn,
-      aws_ssm_parameter.admin_google_ids.arn,
+      aws_ssm_parameter.oauth_client_id.arn,
+      aws_ssm_parameter.oauth_client_secret.arn,
+      aws_ssm_parameter.admin_ids.arn,
       aws_ssm_parameter.token_secret.arn,
     ]
   }
@@ -217,9 +217,9 @@ data "aws_iam_policy_document" "deploy_policy" {
     # main (currently only pwntato) can overwrite production secrets.
     actions = ["ssm:PutParameter", "ssm:AddTagsToResource"]
     resources = [
-      aws_ssm_parameter.google_client_id.arn,
-      aws_ssm_parameter.google_client_secret.arn,
-      aws_ssm_parameter.admin_google_ids.arn,
+      aws_ssm_parameter.oauth_client_id.arn,
+      aws_ssm_parameter.oauth_client_secret.arn,
+      aws_ssm_parameter.admin_ids.arn,
       aws_ssm_parameter.token_secret.arn,
     ]
   }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -50,9 +50,9 @@ data "aws_iam_policy_document" "lambda_policy" {
   statement {
     actions = ["ssm:GetParameter"]
     resources = [
-      aws_ssm_parameter.google_client_id.arn,
-      aws_ssm_parameter.google_client_secret.arn,
-      aws_ssm_parameter.admin_google_ids.arn,
+      aws_ssm_parameter.oauth_client_id.arn,
+      aws_ssm_parameter.oauth_client_secret.arn,
+      aws_ssm_parameter.admin_ids.arn,
       aws_ssm_parameter.token_secret.arn,
     ]
   }
@@ -85,15 +85,17 @@ resource "aws_lambda_function" "main" {
 
   environment {
     variables = {
-      TABLE_NAME               = var.table_name
-      S3_BUCKET                = aws_s3_bucket.content.bucket
-      ENVIRONMENT              = var.environment
-      REDIRECT_URL             = var.redirect_url
-      PUBLIC_BASE_URL          = local.public_base_url
-      SSM_GOOGLE_CLIENT_ID     = aws_ssm_parameter.google_client_id.name
-      SSM_GOOGLE_CLIENT_SECRET = aws_ssm_parameter.google_client_secret.name
-      SSM_ADMIN_GOOGLE_IDS     = aws_ssm_parameter.admin_google_ids.name
-      SSM_TOKEN_SECRET         = aws_ssm_parameter.token_secret.name
+      TABLE_NAME              = var.table_name
+      S3_BUCKET               = aws_s3_bucket.content.bucket
+      ENVIRONMENT             = var.environment
+      REDIRECT_URL            = var.redirect_url
+      PUBLIC_BASE_URL         = local.public_base_url
+      OAUTH_PROVIDER          = var.oauth_provider
+      OKTA_DOMAIN             = var.okta_domain
+      SSM_OAUTH_CLIENT_ID     = aws_ssm_parameter.oauth_client_id.name
+      SSM_OAUTH_CLIENT_SECRET = aws_ssm_parameter.oauth_client_secret.name
+      SSM_ADMIN_IDS           = aws_ssm_parameter.admin_ids.name
+      SSM_TOKEN_SECRET        = aws_ssm_parameter.token_secret.name
     }
   }
 

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -1,19 +1,19 @@
-resource "aws_ssm_parameter" "google_client_id" {
-  name  = "/notoriousmcp/${var.environment}/google_client_id"
+resource "aws_ssm_parameter" "oauth_client_id" {
+  name  = "/notoriousmcp/${var.environment}/oauth_client_id"
   type  = "SecureString"
-  value = var.google_client_id
+  value = var.oauth_client_id
 }
 
-resource "aws_ssm_parameter" "google_client_secret" {
-  name  = "/notoriousmcp/${var.environment}/google_client_secret"
+resource "aws_ssm_parameter" "oauth_client_secret" {
+  name  = "/notoriousmcp/${var.environment}/oauth_client_secret"
   type  = "SecureString"
-  value = var.google_client_secret
+  value = var.oauth_client_secret
 }
 
-resource "aws_ssm_parameter" "admin_google_ids" {
-  name  = "/notoriousmcp/${var.environment}/admin_google_ids"
+resource "aws_ssm_parameter" "admin_ids" {
+  name  = "/notoriousmcp/${var.environment}/admin_ids"
   type  = "SecureString"
-  value = var.admin_google_ids
+  value = var.admin_ids
 }
 
 resource "aws_ssm_parameter" "token_secret" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -11,19 +11,23 @@
 # GitHub Actions secrets required:
 #   TF_STATE_BUCKET       — same as state_bucket above
 #   AWS_DEPLOY_ROLE_ARN   — output of `terraform output deploy_role_arn` after first apply
-#   GOOGLE_CLIENT_ID      — from Google Cloud Console
-#   GOOGLE_CLIENT_SECRET  — from Google Cloud Console
-#   ADMIN_GOOGLE_IDS      — comma-separated Google subject IDs
+#   OAUTH_CLIENT_ID       — OAuth client ID (from Google Cloud Console or Okta)
+#   OAUTH_CLIENT_SECRET   — OAuth client secret
+#   ADMIN_IDS             — comma-separated provider subject IDs (sub claim) for bootstrap admins
 #   TOKEN_SECRET          — min 32-byte random string for HMAC signing (e.g. openssl rand -base64 32)
 #   REDIRECT_URL          — full OAuth callback URL (e.g. https://YOUR_API_GW_DOMAIN/auth/callback)
 #
 # Note: No AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY needed — CI uses OIDC federation.
 
 # Required
-state_bucket         = "notoriousmcp-tfstate-YOUR_ACCOUNT_ID"
-google_client_id     = "YOUR_GOOGLE_CLIENT_ID"
-google_client_secret = "YOUR_GOOGLE_CLIENT_SECRET"
-admin_google_ids     = "GOOGLE_SUB_ID_1,GOOGLE_SUB_ID_2"
+state_bucket        = "notoriousmcp-tfstate-YOUR_ACCOUNT_ID"
+oauth_client_id     = "YOUR_OAUTH_CLIENT_ID"
+oauth_client_secret = "YOUR_OAUTH_CLIENT_SECRET"
+admin_ids           = "SUB_ID_1,SUB_ID_2"
+
+# OAuth provider — defaults to "google". Set to "okta" and provide okta_domain to use Okta.
+# oauth_provider = "okta"
+# okta_domain    = "dev-123.okta.com"
 token_secret         = "YOUR_RANDOM_SECRET_MIN_32_BYTES"
 redirect_url         = "https://YOUR_API_GW_DOMAIN/auth/callback"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,20 +18,40 @@ variable "state_bucket" {
   description = "S3 bucket name for Terraform remote state (created by bootstrap)"
 }
 
-variable "google_client_id" {
+variable "oauth_provider" {
+  type        = string
+  default     = "google"
+  description = "OAuth provider to use: \"google\" (default) or \"okta\""
+  validation {
+    condition     = contains(["google", "okta"], var.oauth_provider)
+    error_message = "oauth_provider must be \"google\" or \"okta\"."
+  }
+}
+
+variable "okta_domain" {
+  type        = string
+  default     = ""
+  description = "Okta domain (e.g. dev-123.okta.com). Required when oauth_provider is \"okta\"."
+  validation {
+    condition     = var.oauth_provider != "okta" || var.okta_domain != ""
+    error_message = "okta_domain is required when oauth_provider is \"okta\"."
+  }
+}
+
+variable "oauth_client_id" {
   type      = string
   sensitive = true
 }
 
-variable "google_client_secret" {
+variable "oauth_client_secret" {
   type      = string
   sensitive = true
 }
 
-variable "admin_google_ids" {
+variable "admin_ids" {
   type        = string
   sensitive   = true
-  description = "Comma-separated Google subject IDs for bootstrap admins"
+  description = "Comma-separated provider subject IDs (sub claim) for bootstrap admins"
 }
 
 variable "token_secret" {


### PR DESCRIPTION
Closes #102.

## Summary

- `OAUTH_PROVIDER=google` (default, unset = Google) — behaviour identical to before
- `OAUTH_PROVIDER=okta` + `OKTA_DOMAIN=dev-123.okta.com` — all Okta endpoints derived from domain via standard OIDC paths; no hardcoded URLs
- Both providers use identical OIDC claims (`sub`, `email`, `name`) so no claim mapping changes needed

## What changed

**Go (`internal/auth/`)**
- `config.go`: added `Provider`, `OktaDomain` fields; `providerEndpoint()` and `userInfoURL()` select provider-specific values; `OverrideTokenURL` replaces `GoogleTokenURL`; `AdminIDs` replaces `AdminGoogleIDs`
- `handler.go`: removed `golang.org/x/oauth2/google` import; uses `cfg.providerEndpoint()` and `cfg.userInfoURL()`; `userInfo`/`fetchUserInfo` replaces `googleUserInfo`/`fetchGoogleUserInfo`
- `middleware.go`: removed Google import; `exchangeRefreshToken` replaces `exchangeGoogleRefreshToken`; uses `cfg.providerEndpoint()`
- `middleware_test.go`: `testMiddlewareCfgWithTokenURL` replaces `testMiddlewareCfgWithGoogleURL`

**Entrypoints**
- `cmd/server/main.go`: reads `OAUTH_PROVIDER`, `OKTA_DOMAIN`, `SSM_OAUTH_CLIENT_ID`, `SSM_OAUTH_CLIENT_SECRET`, `SSM_ADMIN_IDS`
- `cmd/local/main.go`: reads `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `ADMIN_IDS`

**Terraform / infra**
- `variables.tf`: `oauth_provider`, `okta_domain`, `oauth_client_id`, `oauth_client_secret`, `admin_ids` replace Google-specific vars; validation blocks enforce `okta_domain` required when provider is okta
- `ssm.tf`: SSM parameters renamed to `/notoriousmcp/{env}/oauth_client_id`, `oauth_client_secret`, `admin_ids`
- `lambda.tf`: env vars and IAM ARN refs updated
- `iam_deploy.tf`: SSM ARN refs updated
- `deploy.yml`: `TF_VAR_oauth_client_id/secret/admin_ids` from secrets `OAUTH_CLIENT_ID/SECRET/ADMIN_IDS`

## Required before merging to main

1. **Rename GitHub Actions secrets** (Settings → Secrets → Actions):
   - `GOOGLE_CLIENT_ID` → `OAUTH_CLIENT_ID`
   - `GOOGLE_CLIENT_SECRET` → `OAUTH_CLIENT_SECRET`
   - `ADMIN_GOOGLE_IDS` → `ADMIN_IDS`

2. **Wipe DynamoDB and S3 before deploying** — user IDs are provider `sub` values; the old Google records must be cleared so they don't become orphans:
   ```bash
   # Wipe all items from DynamoDB
   aws dynamodb scan --table-name notoriousmcp --attributes-to-get PK SK \
     | jq -c '.Items[]' \
     | while read item; do
         aws dynamodb delete-item --table-name notoriousmcp --key "$item"
       done

   # Empty the S3 bucket
   aws s3 rm s3://$(terraform -chdir=terraform output -raw s3_bucket) --recursive
   ```

3. **Update `terraform/terraform.tfvars`** locally (gitignored): rename `google_client_id/secret/admin_google_ids` → `oauth_client_id/secret/admin_ids`

## Test plan

- [ ] CI passes on this PR (Terraform plan + Go tests)
- [ ] Rename GitHub secrets
- [ ] Wipe DynamoDB + S3
- [ ] Merge and let CI deploy
- [ ] Re-authenticate with Google via Claude Code — confirm end-to-end OAuth flow works with new env var names

🤖 Generated with [Claude Code](https://claude.com/claude-code)