### PR TITLE
Enforce client_id on /auth/login; use registered redirect URI when omitted

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -140,6 +140,7 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
+		log.Printf("login: get client %q: %v", clientID, err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -123,39 +123,43 @@ type oauthStatePayload struct {
 	CodeChallenge     string `json:"cc,omitempty"`
 }
 
-// login initiates the OAuth flow by redirecting to Google.
+// login initiates the OAuth flow by redirecting to the OAuth provider.
 func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	clientRedirectURI := r.URL.Query().Get("redirect_uri")
 
-	// Validate redirect_uri against the configured redirect URL origin to
-	// prevent open-redirect attacks.
-	if clientRedirectURI != "" {
-		if err := ValidateRedirectURI(h.cfg.RedirectURL, clientRedirectURI); err != nil {
-			http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
-			return
-		}
+	// client_id is required — all clients must register via POST /register first.
+	clientID := r.URL.Query().Get("client_id")
+	if clientID == "" {
+		http.Error(w, "client_id is required", http.StatusBadRequest)
+		return
+	}
+	registered, err := h.db.GetClient(ctx, clientID)
+	if errors.Is(err, db.ErrNotFound) {
+		http.Error(w, "invalid client_id", http.StatusUnauthorized)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
 	}
 
-	// If a client_id is provided (dynamically registered client), verify it
-	// exists in the registry and that its stored redirect URI matches.
-	// Clients that omit client_id are allowed through for backwards compatibility
-	// (pre-registration flows and direct token use); the redirect_uri check above
-	// is still the primary open-redirect guard for those callers.
-	if clientID := r.URL.Query().Get("client_id"); clientID != "" {
-		registered, err := h.db.GetClient(ctx, clientID)
-		if errors.Is(err, db.ErrNotFound) {
-			http.Error(w, "invalid client_id", http.StatusUnauthorized)
-			return
-		}
-		if err != nil {
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-		if clientRedirectURI != "" && registered.RedirectURI != clientRedirectURI {
+	// If redirect_uri is provided it must match the registered value exactly.
+	// If omitted, fall back to the registered redirect URI (RFC 6749 §4.1.1).
+	if clientRedirectURI != "" {
+		if registered.RedirectURI != clientRedirectURI {
 			http.Error(w, "redirect_uri mismatch", http.StatusBadRequest)
 			return
 		}
+	} else {
+		clientRedirectURI = registered.RedirectURI
+	}
+
+	// Validate the effective redirect_uri as a defence-in-depth check against
+	// any malformed values that may have been stored at registration time.
+	if err := ValidateRedirectURI(h.cfg.RedirectURL, clientRedirectURI); err != nil {
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		return
 	}
 
 	// PKCE (RFC 7636): if code_challenge is present, method must be S256.

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -184,11 +184,17 @@ func TestWellKnownPublicBaseURL(t *testing.T) {
 }
 
 func TestLoginSetsNonceCookieAndRedirects(t *testing.T) {
-	h := newTestHandler(t)
+	h, dbClient := newTestHandlerWithDB(t)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 
-	req := httptest.NewRequest("GET", "/auth/login?redirect_uri=https://example.com/auth/callback&state=client-state-xyz", nil)
+	clientID := "client-" + randUID()
+	redirectURI := "https://example.com/auth/callback"
+	if err := dbClient.SaveClient(context.Background(), clientID, redirectURI, "test"); err != nil {
+		t.Fatalf("save client: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/auth/login?client_id="+clientID+"&redirect_uri="+redirectURI+"&state=client-state-xyz", nil)
 	req.Host = "example.com"
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
@@ -221,18 +227,24 @@ func TestLoginSetsNonceCookieAndRedirects(t *testing.T) {
 	}
 }
 
-func TestLoginRejectsInvalidRedirectURI(t *testing.T) {
-	h := newTestHandler(t)
+func TestLoginRejectsRedirectURIMismatch(t *testing.T) {
+	h, dbClient := newTestHandlerWithDB(t)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 
-	req := httptest.NewRequest("GET", "/auth/login?redirect_uri=https://evil.com/steal", nil)
+	clientID := "client-" + randUID()
+	if err := dbClient.SaveClient(context.Background(), clientID, "http://127.0.0.1:54321/callback", "test"); err != nil {
+		t.Fatalf("save client: %v", err)
+	}
+
+	// redirect_uri present but doesn't match the registered value.
+	req := httptest.NewRequest("GET", "/auth/login?client_id="+clientID+"&redirect_uri=https://evil.com/steal", nil)
 	req.Host = "example.com"
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
-		t.Errorf("status: got %d want 400 for invalid redirect_uri", w.Code)
+		t.Errorf("status: got %d want 400 for redirect_uri mismatch", w.Code)
 	}
 }
 
@@ -606,9 +618,46 @@ func TestLoginAcceptsRegisteredClientID(t *testing.T) {
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
-	// Proceeds to Google redirect (302) — client_id accepted.
+	// Proceeds to provider redirect (302) — client_id accepted.
 	if w.Code != http.StatusFound {
 		t.Errorf("status: got %d want 302 for valid registered client_id", w.Code)
+	}
+}
+
+func TestLoginRequiresClientID(t *testing.T) {
+	h, _ := newTestHandlerWithDB(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/auth/login?redirect_uri=http://127.0.0.1:54321/callback", nil)
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d want 400 when client_id is absent", w.Code)
+	}
+}
+
+func TestLoginUsesRegisteredRedirectURIWhenOmitted(t *testing.T) {
+	h, dbClient := newTestHandlerWithDB(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	clientID := "client-" + randUID()
+	redirectURI := "http://127.0.0.1:54321/callback"
+	if err := dbClient.SaveClient(context.Background(), clientID, redirectURI, "test"); err != nil {
+		t.Fatalf("save client: %v", err)
+	}
+
+	// Omit redirect_uri — should fall back to the registered value.
+	req := httptest.NewRequest("GET", "/auth/login?client_id="+clientID, nil)
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("status: got %d want 302 when redirect_uri omitted but registered", w.Code)
 	}
 }
 
@@ -855,11 +904,16 @@ func TestTokenEndpointPKCEWrongVerifier(t *testing.T) {
 }
 
 func TestLoginRejectsUnknownCodeChallengeMethod(t *testing.T) {
-	h := newTestHandler(t)
+	h, dbClient := newTestHandlerWithDB(t)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 
-	req := httptest.NewRequest("GET", "/auth/login?code_challenge=abc&code_challenge_method=plain", nil)
+	clientID := "client-" + randUID()
+	if err := dbClient.SaveClient(context.Background(), clientID, "http://127.0.0.1:54321/callback", "test"); err != nil {
+		t.Fatalf("save client: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/auth/login?client_id="+clientID+"&code_challenge=abc&code_challenge_method=plain", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 


### PR DESCRIPTION
## Summary

Closes #77.

- `client_id` is now required at `GET /auth/login`; missing → 400, unknown → 401
- If `redirect_uri` is omitted by the client, falls back to the URI stored at registration time (RFC 6749 §4.1.1) rather than erroring — Claude Code sometimes omits it on repeat auth attempts
- Stored `redirect_uri` is re-validated as defence-in-depth before use
- Removed the backwards-compatibility path that allowed unregistered clients to bypass per-registration redirect URI binding

## Test plan

- [ ] `TestLoginRequiresClientID` — 400 when `client_id` absent
- [ ] `TestLoginRejectsUnknownClientID` — 401 for unregistered `client_id`
- [ ] `TestLoginUsesRegisteredRedirectURIWhenOmitted` — 302 when `redirect_uri` omitted, uses registered value
- [ ] `TestLoginRejectsRedirectURIMismatch` — 400 when provided `redirect_uri` doesn't match registered
- [ ] Existing tests updated to supply a registered `client_id`
- [ ] Full OAuth flow in a fresh Claude Code session after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)