### PR TITLE
Add AUTO_APPROVE_USERS env var (closes #104)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,8 @@ AWS_SECRET_ACCESS_KEY=localpassword
 # Admin bootstrap: comma-separated provider subject IDs (sub claim)
 # Get your sub by logging in once and checking the DynamoDB USER#<sub>#PROFILE item
 ADMIN_IDS=
+
+# Auto-approve new users on first login (default: unset/false).
+# Recommended for Okta deployments where any authenticated user is an employee.
+# Leave unset or set to "false" for Google OAuth (any Google account can auth).
+# AUTO_APPROVE_USERS=true

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Lambda Function  (arm64, 256MB, 30s timeout)
 
 **Manual token flow** (for scripting/testing): register a client via `POST /register`, then visit `/auth/login?client_id=<your-client-id>` in a browser, complete the OAuth flow, copy the `?code=` from the redirect URL, then POST it to `/auth/token`.
 
-New accounts start as **pending** and can only call `check_status`. An admin must promote them to **user** or **admin**.
+New accounts start as **pending** and can only call `check_status`. An admin must promote them to **user** or **admin**. Set `AUTO_APPROVE_USERS=true` to skip manual approval (recommended for Okta deployments where any authenticated user is an employee).
 
 **Admin bootstrap:** The `ADMIN_IDS` SSM parameter holds a comma-separated list of provider subject IDs (`sub` claim) that are forcibly set to `admin` status on every login. This self-heals if admin status is accidentally removed.
 
@@ -390,6 +390,10 @@ ADMIN_IDS=<your provider subject ID>
 # To use Okta instead of Google:
 # OAUTH_PROVIDER=okta
 # OKTA_DOMAIN=dev-123.okta.com
+
+# Auto-approve new users on first login (skip manual admin approval).
+# Recommended for Okta deployments; leave unset for Google OAuth.
+# AUTO_APPROVE_USERS=true
 ```
 
 Add `http://localhost:3000/auth/callback` as an authorized redirect URI in your OAuth app.

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -34,14 +34,15 @@ func main() {
 	adminIDs := strings.Split(os.Getenv("ADMIN_IDS"), ",")
 	tokenSecret := []byte(envOrDefault("TOKEN_SECRET", "local-dev-secret-key-at-least-32!!"))
 	authCfg := auth.Config{
-		Provider:     auth.OAuthProvider(os.Getenv("OAUTH_PROVIDER")),
-		OktaDomain:   os.Getenv("OKTA_DOMAIN"),
-		ClientID:     envOrDefault("OAUTH_CLIENT_ID", "local-client-id"),
-		ClientSecret: envOrDefault("OAUTH_CLIENT_SECRET", "local-client-secret"),
-		RedirectURL:  envOrDefault("REDIRECT_URL", "http://localhost:3000/auth/callback"),
-		AdminIDs:     filterEmpty(adminIDs),
-		TokenSecret:  tokenSecret,
-		TrustProxy:   false,
+		Provider:         auth.OAuthProvider(os.Getenv("OAUTH_PROVIDER")),
+		OktaDomain:       os.Getenv("OKTA_DOMAIN"),
+		ClientID:         envOrDefault("OAUTH_CLIENT_ID", "local-client-id"),
+		ClientSecret:     envOrDefault("OAUTH_CLIENT_SECRET", "local-client-secret"),
+		RedirectURL:      envOrDefault("REDIRECT_URL", "http://localhost:3000/auth/callback"),
+		AdminIDs:         filterEmpty(adminIDs),
+		TokenSecret:      tokenSecret,
+		AutoApproveUsers: os.Getenv("AUTO_APPROVE_USERS") == "true",
+		TrustProxy:       false,
 	}
 
 	authHandler := auth.New(authCfg, dbClient)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -65,15 +65,16 @@ func initHandler() {
 	adminIDsRaw := ssmGet(mustEnv("SSM_ADMIN_IDS"))
 	tokenSecretRaw := ssmGet(mustEnv("SSM_TOKEN_SECRET"))
 	authCfg := auth.Config{
-		Provider:     auth.OAuthProvider(os.Getenv("OAUTH_PROVIDER")),
-		OktaDomain:   os.Getenv("OKTA_DOMAIN"),
-		ClientID:     ssmGet(mustEnv("SSM_OAUTH_CLIENT_ID")),
-		ClientSecret: ssmGet(mustEnv("SSM_OAUTH_CLIENT_SECRET")),
-		RedirectURL:  mustEnv("REDIRECT_URL"),
-		AdminIDs:     filterEmpty(strings.Split(adminIDsRaw, ",")),
-		TokenSecret:  []byte(tokenSecretRaw),
-		TrustProxy:   true,
-		PublicBaseURL: os.Getenv("PUBLIC_BASE_URL"),
+		Provider:         auth.OAuthProvider(os.Getenv("OAUTH_PROVIDER")),
+		OktaDomain:       os.Getenv("OKTA_DOMAIN"),
+		ClientID:         ssmGet(mustEnv("SSM_OAUTH_CLIENT_ID")),
+		ClientSecret:     ssmGet(mustEnv("SSM_OAUTH_CLIENT_SECRET")),
+		RedirectURL:      mustEnv("REDIRECT_URL"),
+		AdminIDs:         filterEmpty(strings.Split(adminIDsRaw, ",")),
+		TokenSecret:      []byte(tokenSecretRaw),
+		AutoApproveUsers: os.Getenv("AUTO_APPROVE_USERS") == "true",
+		TrustProxy:       true,
+		PublicBaseURL:    os.Getenv("PUBLIC_BASE_URL"),
 	}
 
 	authHandler := auth.New(authCfg, dbClient)

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -27,6 +27,11 @@ type Config struct {
 	RedirectURL  string   // e.g. https://notoriousmcp.com/auth/callback
 	AdminIDs     []string // subject IDs (provider "sub" claim) always promoted to admin on login
 	TokenSecret  []byte   // HMAC-SHA256 secret for signing access tokens; min 32 bytes
+	// AutoApproveUsers sets new users to "user" status on first login instead of
+	// "pending". Intended for Okta deployments where any authenticated user is an
+	// employee. Leave false (the default) for Google OAuth deployments where any
+	// Google account holder can authenticate.
+	AutoApproveUsers bool
 	// TrustProxy enables X-Forwarded-Proto scheme detection. Set true only when
 	// running behind a trusted reverse proxy (CloudFront/ALB). Never set on
 	// direct-to-internet deployments — it allows scheme downgrade spoofing.

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"time"
@@ -34,3 +35,8 @@ func (c Config) ProviderEndpoint() (string, string) {
 
 // UserInfoURL exposes Config.userInfoURL for testing.
 func (c Config) UserInfoURL() string { return c.userInfoURL() }
+
+// UpsertUser exposes upsertUser for whitebox unit tests.
+func (h *Handler) UpsertUser(ctx context.Context, sub, email, name, refreshToken string) error {
+	return h.upsertUser(ctx, &userInfo{Sub: sub, Email: email, Name: name}, refreshToken)
+}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -49,6 +49,9 @@ func New(cfg Config, dbClient *db.Client) *Handler {
 	}
 	log.Printf("auth: %d admin ID(s) configured: %v", len(cfg.AdminIDs), adminHints)
 	log.Printf("auth: auto-approve users: %v", cfg.AutoApproveUsers)
+	if cfg.AutoApproveUsers && cfg.provider() != ProviderOkta {
+		log.Printf("auth: WARNING — AUTO_APPROVE_USERS=true with %s: any authenticated account will be auto-approved", cfg.provider())
+	}
 	return &Handler{
 		cfg: cfg,
 		db:  dbClient,
@@ -609,11 +612,11 @@ func (h *Handler) upsertUser(ctx context.Context, info *userInfo, refreshToken s
 	}
 
 	status := models.StatusPending
-	if existing == nil && h.cfg.AutoApproveUsers {
-		status = models.StatusUser
-	}
-	if existing != nil {
+	switch {
+	case existing != nil:
 		status = existing.Status
+	case h.cfg.AutoApproveUsers:
+		status = models.StatusUser
 	}
 
 	// Admin bootstrap: ADMIN_IDS always wins, self-heals on every login.

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -48,6 +48,7 @@ func New(cfg Config, dbClient *db.Client) *Handler {
 		}
 	}
 	log.Printf("auth: %d admin ID(s) configured: %v", len(cfg.AdminIDs), adminHints)
+	log.Printf("auth: auto-approve users: %v", cfg.AutoApproveUsers)
 	return &Handler{
 		cfg: cfg,
 		db:  dbClient,
@@ -608,6 +609,9 @@ func (h *Handler) upsertUser(ctx context.Context, info *userInfo, refreshToken s
 	}
 
 	status := models.StatusPending
+	if existing == nil && h.cfg.AutoApproveUsers {
+		status = models.StatusUser
+	}
 	if existing != nil {
 		status = existing.Status
 	}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -903,6 +903,123 @@ func TestTokenEndpointPKCEWrongVerifier(t *testing.T) {
 	}
 }
 
+// ---- upsertUser / AutoApproveUsers tests ----
+
+func newTestHandlerWithDBAndConfig(t *testing.T, cfg auth.Config) (*auth.Handler, *db.Client) {
+	t.Helper()
+	dbClient := newTestDBClient(t)
+	return auth.New(cfg, dbClient), dbClient
+}
+
+func baseAutoApproveConfig() auth.Config {
+	return auth.Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "https://example.com/auth/callback",
+		TokenSecret:  []byte("test-secret-key-at-least-32-bytes!!"),
+		TrustProxy:   true,
+	}
+}
+
+func TestUpsertUserAutoApproveNewUser(t *testing.T) {
+	cfg := baseAutoApproveConfig()
+	cfg.AutoApproveUsers = true
+	h, dbClient := newTestHandlerWithDBAndConfig(t, cfg)
+
+	sub := "auto-" + randUID()
+	t.Cleanup(func() { _ = dbClient.DeleteUser(context.Background(), sub) })
+
+	if err := h.UpsertUser(context.Background(), sub, "a@example.com", "Alice", ""); err != nil {
+		t.Fatalf("upsertUser: %v", err)
+	}
+
+	u, err := dbClient.GetUser(context.Background(), sub)
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if u.Status != "user" {
+		t.Errorf("status: got %q want %q", u.Status, "user")
+	}
+}
+
+func TestUpsertUserAutoApproveDefaultPending(t *testing.T) {
+	cfg := baseAutoApproveConfig()
+	cfg.AutoApproveUsers = false
+	h, dbClient := newTestHandlerWithDBAndConfig(t, cfg)
+
+	sub := "pending-" + randUID()
+	t.Cleanup(func() { _ = dbClient.DeleteUser(context.Background(), sub) })
+
+	if err := h.UpsertUser(context.Background(), sub, "b@example.com", "Bob", ""); err != nil {
+		t.Fatalf("upsertUser: %v", err)
+	}
+
+	u, err := dbClient.GetUser(context.Background(), sub)
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if u.Status != "pending" {
+		t.Errorf("status: got %q want %q", u.Status, "pending")
+	}
+}
+
+func TestUpsertUserAutoApproveReturningUserUnchanged(t *testing.T) {
+	// A returning user who was already approved should not have their status reset.
+	cfg := baseAutoApproveConfig()
+	cfg.AutoApproveUsers = true
+	h, dbClient := newTestHandlerWithDBAndConfig(t, cfg)
+
+	sub := "returning-" + randUID()
+	t.Cleanup(func() { _ = dbClient.DeleteUser(context.Background(), sub) })
+
+	// First login — gets auto-approved to "user".
+	if err := h.UpsertUser(context.Background(), sub, "c@example.com", "Carol", ""); err != nil {
+		t.Fatalf("first upsertUser: %v", err)
+	}
+
+	// Simulate admin manually demoting to banned status.
+	u, _ := dbClient.GetUser(context.Background(), sub)
+	u.Status = "banned"
+	if err := dbClient.SaveUser(context.Background(), u); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
+
+	// Second login — auto-approve must NOT override existing status.
+	if err := h.UpsertUser(context.Background(), sub, "c@example.com", "Carol", ""); err != nil {
+		t.Fatalf("second upsertUser: %v", err)
+	}
+
+	u2, err := dbClient.GetUser(context.Background(), sub)
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if u2.Status != "banned" {
+		t.Errorf("status: got %q want %q (existing status must be preserved)", u2.Status, "banned")
+	}
+}
+
+func TestUpsertUserAutoApproveAdminBootstrapWins(t *testing.T) {
+	sub := "admin-" + randUID()
+	cfg := baseAutoApproveConfig()
+	cfg.AutoApproveUsers = true
+	cfg.AdminIDs = []string{sub}
+	h, dbClient := newTestHandlerWithDBAndConfig(t, cfg)
+
+	t.Cleanup(func() { _ = dbClient.DeleteUser(context.Background(), sub) })
+
+	if err := h.UpsertUser(context.Background(), sub, "d@example.com", "Dave", ""); err != nil {
+		t.Fatalf("upsertUser: %v", err)
+	}
+
+	u, err := dbClient.GetUser(context.Background(), sub)
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if u.Status != "admin" {
+		t.Errorf("status: got %q want %q (admin bootstrap must win over auto-approve)", u.Status, "admin")
+	}
+}
+
 func TestLoginRejectsUnknownCodeChallengeMethod(t *testing.T) {
 	h, dbClient := newTestHandlerWithDB(t)
 	mux := http.NewServeMux()

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -92,6 +92,7 @@ resource "aws_lambda_function" "main" {
       PUBLIC_BASE_URL         = local.public_base_url
       OAUTH_PROVIDER          = var.oauth_provider
       OKTA_DOMAIN             = var.okta_domain
+      AUTO_APPROVE_USERS      = var.auto_approve_users ? "true" : ""
       SSM_OAUTH_CLIENT_ID     = aws_ssm_parameter.oauth_client_id.name
       SSM_OAUTH_CLIENT_SECRET = aws_ssm_parameter.oauth_client_secret.name
       SSM_ADMIN_IDS           = aws_ssm_parameter.admin_ids.name

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -26,8 +26,9 @@ oauth_client_secret = "YOUR_OAUTH_CLIENT_SECRET"
 admin_ids           = "SUB_ID_1,SUB_ID_2"
 
 # OAuth provider — defaults to "google". Set to "okta" and provide okta_domain to use Okta.
-# oauth_provider = "okta"
-# okta_domain    = "dev-123.okta.com"
+# oauth_provider     = "okta"
+# okta_domain        = "dev-123.okta.com"
+# auto_approve_users = true   # set true for Okta; leave false (default) for Google
 token_secret         = "YOUR_RANDOM_SECRET_MIN_32_BYTES"
 redirect_url         = "https://YOUR_API_GW_DOMAIN/auth/callback"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,6 +38,12 @@ variable "okta_domain" {
   }
 }
 
+variable "auto_approve_users" {
+  type        = bool
+  default     = false
+  description = "Auto-approve new users on first login (set to true for Okta deployments where any authenticated user is an employee)."
+}
+
 variable "oauth_client_id" {
   type      = string
   sensitive = true


### PR DESCRIPTION
## Summary

- Adds `AutoApproveUsers bool` to `auth.Config` — when true, new users get `user` status on first login instead of `pending`
- Only applies to new users (`existing == nil`); returning users keep their current status
- Admin bootstrap (`ADMIN_IDS`) always wins, regardless of this setting
- Default is `false` — existing deployments are unaffected
- Logs effective setting at startup alongside admin ID count

## Files changed

- `internal/auth/config.go` — new `AutoApproveUsers` field with doc comment
- `internal/auth/handler.go` — apply in `upsertUser`; log at startup
- `internal/auth/export_test.go` — expose `UpsertUser` for whitebox tests
- `internal/auth/handler_test.go` — 4 new integration tests covering all cases from the issue spec
- `cmd/server/main.go` — wire `AUTO_APPROVE_USERS=true` env var
- `terraform/variables.tf` — `auto_approve_users` bool variable (default `false`)
- `terraform/lambda.tf` — pass as `AUTO_APPROVE_USERS` env var to Lambda
- `.env.example` — document the setting with usage guidance

## Test plan

- [ ] CI integration tests pass (DynamoDB Local wired in CI)
- [ ] `TestUpsertUserAutoApproveNewUser` — new user + true → status `user`
- [ ] `TestUpsertUserAutoApproveDefaultPending` — new user + false → status `pending`
- [ ] `TestUpsertUserAutoApproveReturningUserUnchanged` — returning user → existing status preserved
- [ ] `TestUpsertUserAutoApproveAdminBootstrapWins` — admin ID + true → status `admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)